### PR TITLE
Don't truncate update scripts' log files

### DIFF
--- a/cloud-services/mbl-cloud-client/scripts/arm_update_activate.sh
+++ b/cloud-services/mbl-cloud-client/scripts/arm_update_activate.sh
@@ -37,7 +37,8 @@ set -x
 
 if [ -n "$ARM_UPDATE_ACTIVATE_LOG_PATH" ]; then
     # Redirect stdout and stderr to the log file
-    exec >"$ARM_UPDATE_ACTIVATE_LOG_PATH" 2>&1
+    exec >>"$ARM_UPDATE_ACTIVE_DETAILS_LOG_PATH" 2>&1
+    printf "%s: %s\n" "$(date '+%FT%T%z')" "Starting arm_update_activate.sh"
 fi
 
 # Returns successfully if the given path is a directory and is empty (except

--- a/cloud-services/mbl-cloud-client/scripts/arm_update_active_details.sh
+++ b/cloud-services/mbl-cloud-client/scripts/arm_update_active_details.sh
@@ -37,7 +37,8 @@
     
 if [ -n "$ARM_UPDATE_ACTIVE_DETAILS_LOG_PATH" ]; then
     # Redirect stdout and stderr to the log file
-    exec >"$ARM_UPDATE_ACTIVE_DETAILS_LOG_PATH" 2>&1
+    exec >>"$ARM_UPDATE_ACTIVE_DETAILS_LOG_PATH" 2>&1
+    printf "%s: %s\n" "$(date '+%FT%T%z')" "Starting arm_update_active_details.sh"
 fi
 
 # header directory


### PR DESCRIPTION
For IOTMBL-686: Log partition

arm_update_activate.sh:
arm_update_active_details.sh:
* We've now got a proper log partition in MBL and a way to easily add
  logrotate configs. Append to log files rather than truncating them
  when they're opened - we can trust logrotate to keep the log sizes
  down now.
* While I'm here, log the time when these scripts are run. Ideally we'd
  prefix each line of output with a timestamp but that's not within the
  scope of IOTMBL-686.