### PR TITLE
Write arm_update_activate logs to the correct file

### DIFF
--- a/cloud-services/mbl-cloud-client/scripts/arm_update_activate.sh
+++ b/cloud-services/mbl-cloud-client/scripts/arm_update_activate.sh
@@ -37,7 +37,7 @@ set -x
 
 if [ -n "$ARM_UPDATE_ACTIVATE_LOG_PATH" ]; then
     # Redirect stdout and stderr to the log file
-    exec >>"$ARM_UPDATE_ACTIVE_DETAILS_LOG_PATH" 2>&1
+    exec >>"$ARM_UPDATE_ACTIVATE_LOG_PATH" 2>&1
     printf "%s: %s\n" "$(date '+%FT%T%z')" "Starting arm_update_activate.sh"
 fi
 


### PR DESCRIPTION
For IOTMBL-815: arm_update_activate.sh writes to the wrong log file