### PR TITLE
Integrate mbl-app-update-manager with mbl-cloud-client (#16)

### DIFF
--- a/application-framework/mbl-app-lifecycle-manager/mbl/AppLifecycleManager.py
+++ b/application-framework/mbl-app-lifecycle-manager/mbl/AppLifecycleManager.py
@@ -261,8 +261,8 @@ class AppLifecycleManager:
         if result != Error.SUCCESS:
             self._log_error_return("_create_container", result, container_id)
             return result
-        working_dir = os.path.join(APPS_INSTALL_ROOT_DIR, application_id)
-        if not os.path.isdir(working_dir):
+        bundle_path = os.path.join(APPS_INSTALL_ROOT_DIR, application_id)
+        if not os.path.isdir(bundle_path):
             result = Error.ERR_APP_NOT_FOUND
             self._log_error_return(
                 "create_container",
@@ -273,8 +273,7 @@ class AppLifecycleManager:
             return result
         self.logger.info("Create container: {}".format(container_id))
         _, result = self._run_command(
-            ["runc", "create", container_id],
-            working_dir,
+            ["runc", "create", "--bundle", bundle_path, container_id],
             stdin=subprocess.DEVNULL,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
@@ -401,7 +400,6 @@ class AppLifecycleManager:
     def _run_command(
         self,
         command,
-        working_dir=None,
         stdin=None,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
@@ -416,7 +414,7 @@ class AppLifecycleManager:
         """
         self.logger.debug("Executing command: {}".format(command))
         result = subprocess.run(
-            command, cwd=working_dir, stdin=stdin, stdout=stdout, stderr=stderr
+            command, stdin=stdin, stdout=stdout, stderr=stderr
         )
         output = ""
         if result.stdout:

--- a/cloud-services/mbl-cloud-client/scripts/arm_update_common.sh
+++ b/cloud-services/mbl-cloud-client/scripts/arm_update_common.sh
@@ -22,6 +22,7 @@
 LOCAL_CONFIG_PATH=/opt/arm/arm_update_local_config.sh
 ROOTFS_TYPE="ext4"
 FLAGSFS_TYPE="ext4"
+SAVED_HEADER_PATH="/mnt/flags/header"
 
 # Given an exit status, exits with that status if it is non-zero, otherwise
 # does nothing
@@ -129,5 +130,6 @@ emodFsType="$3"
 get_active_root_device() {
     lsblk -nrpo NAME,MOUNTPOINT | grep -e ".* /$" | cut -d ' ' -f1
 }
+
 
 [ -e "$LOCAL_CONFIG_PATH" ] && . "$LOCAL_CONFIG_PATH"

--- a/cloud-services/mbl-cloud-client/source/log.cpp
+++ b/cloud-services/mbl-cloud-client/source/log.cpp
@@ -134,7 +134,7 @@ MblError log_init()
     mbed_trace_init();
 
     // No colors, no carriage returns, print all log levels
-    mbed_trace_config_set(TRACE_ACTIVE_LEVEL_ALL);
+    mbed_trace_config_set(TRACE_ACTIVE_LEVEL_INFO);
 
     mbed_trace_print_function_set(mbl_trace_print_handler);
     mbed_trace_cmdprint_function_set(mbl_trace_print_handler);

--- a/firmware-management/mbl-app-update-manager/mbl-app-update-manager
+++ b/firmware-management/mbl-app-update-manager/mbl-app-update-manager
@@ -10,12 +10,14 @@ import argparse
 import os
 import subprocess
 import logging
+import tarfile
 from enum import Enum
 import mbl.AppManager as apm
 import mbl.AppLifecycleManager as alm
 
 __version__ = "1.0"
 APP_STOP_TIMEOUT = 3
+SRC_IPK_PATH = "/mnt/cache/opkg/src_ipk"
 
 
 class Error(Enum):
@@ -199,6 +201,81 @@ def install_package_and_run_container(package_path):
     return Error.SUCCESS
 
 
+def extract_ipks_from_tar(tar_path):
+    """
+    Extracts .ipk files from a tar file.
+
+    Returns a 2-tuple (ipk_paths, error) where ipk_paths is a list of paths to
+    extracted .ipk files and error is one of:
+        Error.SUCCESS
+        Error.ERR_TAR_FAILURE
+    """
+    logging.info(
+        "Extracting .ipk files from update payload tar file {}".format(
+            tar_path
+        )
+    )
+    try:
+        ipk_paths = []
+        ipk_members = []
+        with tarfile.open(tar_path) as tar:
+            search_for_ipks_in_tar(tar_path, tar, ipk_paths, ipk_members)
+            tar.extractall(path=SRC_IPK_PATH, members=ipk_members)
+        if not ipk_paths:
+            logging.info(
+                "No .ipk files found in update payload tar file {}".format(
+                    tar_path
+                )
+            )
+        return (ipk_paths, Error.SUCCESS)
+    except TarError:
+        logging.exception(
+            "Failed to extract .ipk files from tar archive {}".format(tar_path)
+        )
+        return ([], Error.ERR_TAR_FAILURE)
+
+
+def search_for_ipks_in_tar(tar_path, tar, ipk_paths, ipk_members):
+    for tar_info in tar:
+        if os.path.splitext(tar_info.name)[1] != ".ipk":
+            continue
+        if not tar_info.isfile():
+            logging.warning(
+                "Ignoring .ipk file {} from update payload tar "
+                "file {} - it is not a regular file".format(
+                    tar_info.name, tar_path
+                )
+            )
+            continue
+        if os.path.dirname(tar_info.name):
+            logging.warning(
+                "Ignoring .ipk file {} from update payload tar "
+                "file {} - it has directory components".format(
+                    tar_info.name, tar_path
+                )
+            )
+            continue
+        ipk_members.append(tar_info)
+        ipk_paths.append(os.path.join(SRC_IPK_PATH, tar_info.name))
+        logging.info(
+            "Found .ipk file {} in update payload tar file {}".format(
+                tar_info.name, tar_path
+            )
+        )
+
+
+def install_and_run_apps_from_tar(tar_path):
+    ipk_paths, ret = extract_ipks_from_tar(tar_path)
+    if ret != Error.SUCCESS:
+        return ret
+
+    for ipk_path in ipk_paths:
+        ret = install_package_and_run_container(ipk_path)
+        if ret != Error.SUCCESS:
+            return ret
+    return Error.SUCCESS
+
+
 class StoreValidFile(argparse.Action):
     def __call__(self, parser, namespace, values, option_string=None):
         prospective_file = values
@@ -226,11 +303,11 @@ def get_argument_parser():
 
     parser.add_argument(
         "-i",
-        "--install-package",
-        metavar="IPK_FILE",
+        "--install-packages",
+        metavar="UPDATE_PAYLOAD_TAR_FILE",
         required=True,
         action=StoreValidFile,
-        help="Install package on device and run it, input is .ipk file path",
+        help="Install packages from a firmware update tar file and run them",
     )
 
     parser.add_argument(
@@ -262,10 +339,12 @@ def _main():
 
     ret = Error.ERR_OPERATION_FAILED
     try:
-        ret = install_package_and_run_container(args.install_package)
+        ret = install_and_run_apps_from_tar(args.install_packages)
     except subprocess.CalledProcessError as e:
         logger.exception(
-            "Operation failed with subprocess error code: " + str(e.returncode)
+            "Operation failed with subprocess error code: {}".format(
+                e.returncode
+            )
         )
         return Error.ERR_OPERATION_FAILED
     except OSError:

--- a/firmware-management/mbl-app-update-manager/mbl-app-update-manager-daemon
+++ b/firmware-management/mbl-app-update-manager/mbl-app-update-manager-daemon
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+# Copyright (c) 2018 ARM Ltd.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Get the script name from the path
+name=${0##*/}
+# Redirect stdout and stderr to the log file
+exec >>"/var/log/${name}.log" 2>&1
+printf "%s: %s\n" "$(date '+%FT%T%z')" "Starting ${name}"
+
+set -x
+
+wait_for_app_update_file() {
+    set +x
+    echo "Waiting for app update"
+    while ! [ -e "/mnt/cache/do_app_update" ]; do
+        sleep 1
+    done
+    echo "App update starting"
+    set -x
+    rm "/mnt/cache/do_app_update"
+}
+
+update_apps() {
+    mbl-app-update-manager --install-packages "$(cat /mnt/cache/firmware_path)"
+    printf "%s\n" "$?" > /mnt/cache/app_update_rc
+    rm /mnt/cache/firmware_path
+    touch "/mnt/cache/done_app_update"
+}
+
+while true; do
+    wait_for_app_update_file
+    update_apps
+done
+
+# Should never get here
+exit 1


### PR DESCRIPTION
IOTMBL-773: Integrate mbed Client update hook scripts with app
update script (588) and test with techcon demo

Decouple the process that installs apps from the mbl-cloud-client
process by introducing the mbl-app-update-manager-daemon script that
waits for arm_update_activate.sh to indicate that an update is
available.

This is currently done as a hack to avoid a "runc create" error that
we see when the process that runs "runc create" is forked from the
mbl-cloud-client process. This may be due to the resource duplication
involved in forking, but more investigation is required.

Add functionality to extract .ipk files from the update payload tar
file to mbl-app-update-manager so that I don't have to write it in
Shell in arm_update_activate.sh or mbl-app-update-manager-daemon.

Update handling of rootfs updates to expect a rootfs archive inside
the update payload tar file. This allows us to have update payload tar
files that contain both rootfs and app updates.

Remove the support for rootfs archives to be compressed in a variety
of ways - we've standardized rootfs archives across our supported
boards so this is no longer necessary.

In AppLifecycleManager.py, instead of switching the current directory
to the directory for a container and then letting "runc create" infer
the bundle location, explicitly pass "runc create" the bundle location
as an argument. It makes the code a bit easier to follow and means
that the bundle location is logged when "runc create" fails.

Saving the update "header" file to /mnt/flags/rootfs1_header or
/mnt/flags/rootfs2_header doesn't work for app updates because there's
not necessarily a rootfs update at the same time.

Just save the header file to /mnt/flags/header so that it works for
app updates too. This isn't ideal - we'll update the header before we
know whether a rootfs update has actually succeeded or not. A proper
solution will require more thought.

Don't unmount /mnt/flags after a rootfs update is finished - it must
be mounted so that arm_update_active_details.sh can work.

Update arm_update_active_details to work for app updates as well as
rootfs updates.

Turn the logging level of mbl-cloud-client down to INFO - with DEBUG
level messages printed we can run out of space in /var/log before
logrotate runs to help out.