### PR TITLE
Fixed firmware update failure

### DIFF
--- a/cloud-services/mbl-cloud-client/scripts/arm_update_activate.sh
+++ b/cloud-services/mbl-cloud-client/scripts/arm_update_activate.sh
@@ -119,7 +119,7 @@ if ! FIRMWARE_FILES=$(${tar_list_content_cmd} "${FIRMWARE}"); then
     exit 46
 fi
 
-if ! ROOTFS_FILE=$(echo "${FIRMWARE_FILES}" | grep '^mbl-console.*rootfs\.tar\.xz$'); then
+if ! ROOTFS_FILE=$(echo "${FIRMWARE_FILES}" | grep '^rootfs\.tar\.xz$'); then
     # ------------------------------------------------------------------------------
     # Install app updates from payload file
     # ------------------------------------------------------------------------------

--- a/firmware-management/mbl-app-update-manager/mbl-app-update-manager-daemon
+++ b/firmware-management/mbl-app-update-manager/mbl-app-update-manager-daemon
@@ -11,10 +11,6 @@ exec >>"/var/log/${name}.log" 2>&1
 printf "%s: %s\n" "$(date '+%FT%T%z')" "Starting ${name}"
 set -x
 
-# Clean posible leftover from last app updates
-rm -f /scratch/do_app_update
-rm -f /scratch/done_app_update
-
 wait_for_app_update_file() {
     set +x
     echo "Waiting for app update"


### PR DESCRIPTION
Fixed firmware update failure (endless loop, no firmware update)
Fixed path (from /mnt/cache/ to /scratch/).
Before the fix every update from Pelion was treated as app update which caused an endless loop waiting for the demon to finish his work (demon didn't do anything as it is a firmware update).
Also, paths to /mnt/cache/ were changed to /scratch/.
* Note#1: didn't do any code improving tasks as these script should be replaced with python scripts in the future. only fixed the bugs.
* Note#2: firmware image should be wrapped in a tar file and this new tar file should be used in Pelion.


Task: IOTMBL-892