### PR TITLE
IOTMBL-934 Remove instruction to run system test from test files

### DIFF
--- a/application-framework/mbl-app-lifecycle-manager/tests/target/test_mbl-app-lifecycle-manager.py
+++ b/application-framework/mbl-app-lifecycle-manager/tests/target/test_mbl-app-lifecycle-manager.py
@@ -3,16 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""
-Pytest for testing mbl app lifecycle manager.
-
-This test file requires the ipk
-"app-lifecycle-manager-test-package_1.0_armv7vet2hf-neon.ipk" to be placed in
-the same directory.
-The ipk is available from:
-https://github.com/ARMmbed/mbl-scratch/tree/64c21a344c4eebd46d7308338d71ba510dc
-20323/mbl-app-lifecycle-manager/tests/data
-"""
+"""Pytest for testing mbl app lifecycle manager."""
 
 import subprocess
 import os

--- a/firmware-management/mbl-app-manager/tests/native/test_case_generator_mbl-app-manager.py
+++ b/firmware-management/mbl-app-manager/tests/native/test_case_generator_mbl-app-manager.py
@@ -8,7 +8,6 @@ This script generates test files for testing ARM MBL App Manager using pytest.
 
 Test files consist of pairs of .ipk and .json config files.
 Output directory "test_files" holds several of such pairs.
-The output directory "test_files" should be pushed to device to /home/app/
 This script generate 4 test cases: 2 positive tests and 2 negative tests.
 """
 

--- a/firmware-management/mbl-app-manager/tests/target/test_mbl-app-manager.py
+++ b/firmware-management/mbl-app-manager/tests/target/test_mbl-app-manager.py
@@ -3,23 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""
-Pytest for testing MBL App Manager.
-
-This pytest tests expect a directory "test_files" to exist under
-/home/app/ directory. This directory should contain ipk files and
-test case configuration files (JSON)
-Test parse all configuration files and run each test case.
-Basic test flow:
-1. Remove previous package_name (In case it is already installed on device)
-2. Install package and verify expected return code
-3. If Install should succeed - verify MD5 of all package installed file and
-   compare to expected MD5 value
-4. Remove package and verify expected return code (even if install was
-   expected to fail as the expected return code for remove operation is also
-   given in the config.
-Note: if any of the above steps behave different than expected - test fail.
-"""
+"""Pytest for testing MBL App Manager."""
 
 import subprocess
 import json


### PR DESCRIPTION
IOTMBL-934 Remove instruction to run tests from test files.

This has now been documented on Confluence.
https://confluence.arm.com/display/mbedlinux/Running+System+Tests