### PR TITLE
IOTMBL-964 Amend hostname test to look for the "mbed-linux-os-" prefix

### DIFF
--- a/mbl-core/tests/devices/hostname/test_hostname.py
+++ b/mbl-core/tests/devices/hostname/test_hostname.py
@@ -142,7 +142,7 @@ class TestHostname:
         os.remove(HOSTNAME_USER_FILE)
         self._run_hostname_script()
         hostname = subprocess.run(HOSTNAME_CMD, stdout=subprocess.PIPE)
-        assert hostname.stdout.decode("utf-8").find("mbed_linux_") == 0
+        assert hostname.stdout.decode("utf-8").find("mbed-linux-os-") == 0
 
     def _setup_cfg_hostname(self, hostname_factory, hostname_user=None):
         """setup factory and user configurations."""


### PR DESCRIPTION
* Change expected hostname in system test file.
* Rename test file to follow convention used in other directories of the project for test files.

Jira ticket:
https://jira.arm.com/browse/IOTMBL-964

Jenkins build:
http://jenkins.mbed-linux.arm.com/job/hk-test-job-2/1/

Test performed:
* Verify hostname on shell prompt is as expected `root@mbed-linux-os-6392:~#` 

Action to take after merge:
* Verify that LAVA testing is not broken