### PR TITLE
 mbed-cloud-client version updated to 2.0.1 

### DIFF
--- a/cloud-services/mbl-cloud-client/mbed-cloud-client.lib
+++ b/cloud-services/mbl-cloud-client/mbed-cloud-client.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-cloud-client/#9b0bc6a2f3f1f5dbb5be1827db83004d531b99c9
+https://github.com/ARMmbed/mbed-cloud-client/#f80f2047657a316fe0f334081f030c6825612afc

--- a/cloud-services/mbl-cloud-client/pal-platform/Device/OpenWRT_Generic/OpenWRT_Generic.cmake
+++ b/cloud-services/mbl-cloud-client/pal-platform/Device/OpenWRT_Generic/OpenWRT_Generic.cmake
@@ -1,12 +1,12 @@
 #################################################################################
 #  Copyright 2016, 2017 ARM Ltd.
-#
+#  
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
 #  You may obtain a copy of the License at
-#
+#  
 #      http://www.apache.org/licenses/LICENSE-2.0
-#
+#  
 #  Unless required by applicable law or agreed to in writing, software
 #  distributed under the License is distributed on an "AS IS" BASIS,
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/cloud-services/mbl-cloud-client/pal-platform/Device/Yocto_Generic/Yocto_Generic.cmake
+++ b/cloud-services/mbl-cloud-client/pal-platform/Device/Yocto_Generic/Yocto_Generic.cmake
@@ -1,12 +1,12 @@
 #################################################################################
 #  Copyright 2016, 2017 ARM Ltd.
-#
+#  
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
 #  You may obtain a copy of the License at
-#
+#  
 #      http://www.apache.org/licenses/LICENSE-2.0
-#
+#  
 #  Unless required by applicable law or agreed to in writing, software
 #  distributed under the License is distributed on an "AS IS" BASIS,
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/cloud-services/mbl-cloud-client/pal-platform/Device/x86_x64/x86_x64.cmake
+++ b/cloud-services/mbl-cloud-client/pal-platform/Device/x86_x64/x86_x64.cmake
@@ -1,12 +1,12 @@
 #################################################################################
 #  Copyright 2016, 2017 ARM Ltd.
-#
+#  
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
 #  You may obtain a copy of the License at
-#
+#  
 #      http://www.apache.org/licenses/LICENSE-2.0
-#
+#  
 #  Unless required by applicable law or agreed to in writing, software
 #  distributed under the License is distributed on an "AS IS" BASIS,
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/cloud-services/mbl-cloud-client/pal-platform/Middleware/fatfs_0.11/fatfs_0.11a.cmake
+++ b/cloud-services/mbl-cloud-client/pal-platform/Middleware/fatfs_0.11/fatfs_0.11a.cmake
@@ -1,12 +1,12 @@
 #################################################################################
 #  Copyright 2016, 2017 ARM Ltd.
-#
+#  
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
 #  You may obtain a copy of the License at
-#
+#  
 #      http://www.apache.org/licenses/LICENSE-2.0
-#
+#  
 #  Unless required by applicable law or agreed to in writing, software
 #  distributed under the License is distributed on an "AS IS" BASIS,
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -14,9 +14,10 @@
 #  limitations under the License.
 #################################################################################
 
-include_directories(./pal-platform/Middleware/fatfs_0.11a/fatfs_0.11a/src)
+include_directories(./pal-platform/Middleware/fatfs_0.11a/fatfs_0.11a/src)	
 
 
 #add_subdirectory ("./Platform/Middleware/lwip_1.4.1/lwip_1.4.1")
 set (EXTRA_CMAKE_DIRS ${EXTRA_CMAKE_DIRS} "./pal-platform/Middleware/fatfs_0.11a/fatfs_0.11a")
 list (APPEND PLATFORM_LIBS fatfs_0.11a)
+      

--- a/cloud-services/mbl-cloud-client/pal-platform/Middleware/lwip_1.4.1/lwip_1.4.1.cmake
+++ b/cloud-services/mbl-cloud-client/pal-platform/Middleware/lwip_1.4.1/lwip_1.4.1.cmake
@@ -1,12 +1,12 @@
 #################################################################################
 #  Copyright 2016, 2017 ARM Ltd.
-#
+#  
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
 #  You may obtain a copy of the License at
-#
+#  
 #      http://www.apache.org/licenses/LICENSE-2.0
-#
+#  
 #  Unless required by applicable law or agreed to in writing, software
 #  distributed under the License is distributed on an "AS IS" BASIS,
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,9 +20,9 @@ add_definitions("-DLWIP_SOCKET")
 SET_COMPILER_DBG_RLZ_FLAG (CMAKE_EXE_LINKER_FLAGS "-defsym=__ram_vector_table__=1")
 
 #  additional directories to look for CMakeLists.txt
-include_directories(./pal-platform/Middleware/lwip_1.4.1/lwip_1.4.1/port)
-include_directories(./pal-platform/Middleware/lwip_1.4.1/lwip_1.4.1/port/arch)
-include_directories(./pal-platform/Middleware/lwip_1.4.1/lwip_1.4.1/src)
+include_directories(./pal-platform/Middleware/lwip_1.4.1/lwip_1.4.1/port) 
+include_directories(./pal-platform/Middleware/lwip_1.4.1/lwip_1.4.1/port/arch) 
+include_directories(./pal-platform/Middleware/lwip_1.4.1/lwip_1.4.1/src) 
 include_directories(./pal-platform/Middleware/lwip_1.4.1/lwip_1.4.1/src/include)
 include_directories(./pal-platform/Middleware/lwip_1.4.1/lwip_1.4.1/src/include/ipv4)
 include_directories(./pal-platform/Middleware/lwip_1.4.1/lwip_1.4.1/src/include/ipv4/lwip)
@@ -30,12 +30,13 @@ include_directories(./pal-platform/Middleware/lwip_1.4.1/lwip_1.4.1/src/include/
 include_directories(./pal-platform/Middleware/lwip_1.4.1/lwip_1.4.1/src/include/ipv6/lwip)
 include_directories(./pal-platform/Middleware/lwip_1.4.1/lwip_1.4.1/src/include/lwip)
 include_directories(./pal-platform/Middleware/lwip_1.4.1/lwip_1.4.1/src/include/netif)
-include_directories(./pal-platform/Middleware/lwip_1.4.1/lwip_1.4.1/src/include/posix)
-include_directories(./pal-platform/Middleware/lwip_1.4.1/lwip_1.4.1/src/netif)
-include_directories(./pal-platform/Middleware/lwip_1.4.1/lwip_1.4.1/src/netif/ppp)
+include_directories(./pal-platform/Middleware/lwip_1.4.1/lwip_1.4.1/src/include/posix)             
+include_directories(./pal-platform/Middleware/lwip_1.4.1/lwip_1.4.1/src/netif)             
+include_directories(./pal-platform/Middleware/lwip_1.4.1/lwip_1.4.1/src/netif/ppp) 
 
 
 
 #add_subdirectory ("./Platform/Middleware/lwip_1.4.1/lwip_1.4.1")
 set (EXTRA_CMAKE_DIRS ${EXTRA_CMAKE_DIRS} "./pal-platform/Middleware/lwip_1.4.1/lwip_1.4.1")
 list (APPEND PLATFORM_LIBS lwip_1.4.1)
+      

--- a/cloud-services/mbl-cloud-client/pal-platform/Middleware/mbedtls/mbedtls.cmake
+++ b/cloud-services/mbl-cloud-client/pal-platform/Middleware/mbedtls/mbedtls.cmake
@@ -1,12 +1,12 @@
 #################################################################################
 #  Copyright 2016, 2017 ARM Ltd.
-#
+#  
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
 #  You may obtain a copy of the License at
-#
+#  
 #      http://www.apache.org/licenses/LICENSE-2.0
-#
+#  
 #  Unless required by applicable law or agreed to in writing, software
 #  distributed under the License is distributed on an "AS IS" BASIS,
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -29,3 +29,4 @@ message(status "device = ${PAL_TARGET_DEVICE}")
 set (EXTRA_CMAKE_DIRS ${EXTRA_CMAKE_DIRS} "${CMAKE_SOURCE_DIR}/pal-platform/Middleware/mbedtls/mbedtls")
 
 list (APPEND SRC_LIBS mbedtls mbedcrypto mbedx509)
+      

--- a/cloud-services/mbl-cloud-client/pal-platform/Middleware/mmcau_2.0.0/mmcau_2.0.0.cmake
+++ b/cloud-services/mbl-cloud-client/pal-platform/Middleware/mmcau_2.0.0/mmcau_2.0.0.cmake
@@ -1,12 +1,12 @@
 #################################################################################
 #  Copyright 2016, 2017 ARM Ltd.
-#
+#  
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
 #  You may obtain a copy of the License at
-#
+#  
 #      http://www.apache.org/licenses/LICENSE-2.0
-#
+#  
 #  Unless required by applicable law or agreed to in writing, software
 #  distributed under the License is distributed on an "AS IS" BASIS,
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,7 +15,8 @@
 #################################################################################
 
 #  additional directories to look for CMakeLists.txt
-include_directories(./pal-platform/Middleware/mmcau_2.0.0/mmcau_2.0.0)
+include_directories(./pal-platform/Middleware/mmcau_2.0.0/mmcau_2.0.0) 
 
 set (EXTRA_CMAKE_DIRS ${EXTRA_CMAKE_DIRS} "./pal-platform/Middleware/mmcau_2.0.0/mmcau_2.0.0")
 list (APPEND PLATFORM_LIBS mmcau_2.0.0)
+      

--- a/cloud-services/mbl-cloud-client/pal-platform/Middleware/sdmmc_2.0.0/sdmmc_2.0.0.cmake
+++ b/cloud-services/mbl-cloud-client/pal-platform/Middleware/sdmmc_2.0.0/sdmmc_2.0.0.cmake
@@ -1,12 +1,12 @@
 #################################################################################
 #  Copyright 2016, 2017 ARM Ltd.
-#
+#  
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
 #  You may obtain a copy of the License at
-#
+#  
 #      http://www.apache.org/licenses/LICENSE-2.0
-#
+#  
 #  Unless required by applicable law or agreed to in writing, software
 #  distributed under the License is distributed on an "AS IS" BASIS,
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,3 +19,4 @@ include_directories(./pal-platform/Middleware/sdmmc_2.0.0/sdmmc_2.0.0/inc)
 #add_subdirectory ("./Platform/Middleware/lwip_1.4.1/lwip_1.4.1")
 set (EXTRA_CMAKE_DIRS ${EXTRA_CMAKE_DIRS} "./pal-platform/Middleware/sdmmc_2.0.0/sdmmc_2.0.0")
 list (APPEND PLATFORM_LIBS sdmmc_2.0.0)
+      

--- a/cloud-services/mbl-cloud-client/pal-platform/OS/Linux_Native/Linux_Native.cmake
+++ b/cloud-services/mbl-cloud-client/pal-platform/OS/Linux_Native/Linux_Native.cmake
@@ -1,12 +1,12 @@
 #################################################################################
 #  Copyright 2016, 2017 ARM Ltd.
-#
+#  
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
 #  You may obtain a copy of the License at
-#
+#  
 #      http://www.apache.org/licenses/LICENSE-2.0
-#
+#  
 #  Unless required by applicable law or agreed to in writing, software
 #  distributed under the License is distributed on an "AS IS" BASIS,
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/cloud-services/mbl-cloud-client/pal-platform/OS/Linux_OpenWRT/Linux_OpenWRT.cmake
+++ b/cloud-services/mbl-cloud-client/pal-platform/OS/Linux_OpenWRT/Linux_OpenWRT.cmake
@@ -1,12 +1,12 @@
 #################################################################################
 #  Copyright 2016, 2017 ARM Ltd.
-#
+#  
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
 #  You may obtain a copy of the License at
-#
+#  
 #      http://www.apache.org/licenses/LICENSE-2.0
-#
+#  
 #  Unless required by applicable law or agreed to in writing, software
 #  distributed under the License is distributed on an "AS IS" BASIS,
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/cloud-services/mbl-cloud-client/pal-platform/OS/Linux_Yocto_v2.2/Linux_Yocto_v2.2.cmake
+++ b/cloud-services/mbl-cloud-client/pal-platform/OS/Linux_Yocto_v2.2/Linux_Yocto_v2.2.cmake
@@ -1,12 +1,12 @@
 #################################################################################
 #  Copyright 2016, 2017 ARM Ltd.
-#
+#  
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
 #  You may obtain a copy of the License at
-#
+#  
 #      http://www.apache.org/licenses/LICENSE-2.0
-#
+#  
 #  Unless required by applicable law or agreed to in writing, software
 #  distributed under the License is distributed on an "AS IS" BASIS,
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/cloud-services/mbl-cloud-client/pal-platform/PULL_REQUEST_TEMPLATE
+++ b/cloud-services/mbl-cloud-client/pal-platform/PULL_REQUEST_TEMPLATE
@@ -11,3 +11,7 @@ OS type and version:
 Related mbed-client-pal PR/branch(if any):
 
 Related pal-example PR/branch(if any):
+
+
+
+

--- a/cloud-services/mbl-cloud-client/pal-platform/README.md
+++ b/cloud-services/mbl-cloud-client/pal-platform/README.md
@@ -1,7 +1,7 @@
 # pal-platform
 Repository to hold deployment information for PAL-supported OS's, toolchains, middleware and devices
 
-Current version is 1.4.0, copied from from [pal platfrom 1.4.0 release][pal-platfrom-1-4-0-release].
+Current version is 2.0.1, copied from from [pal platfrom 2.0.1 release][pal-platfrom-2-0-1-release].
 
 ## Table of Contents
 
@@ -10,4 +10,4 @@ Current version is 1.4.0, copied from from [pal platfrom 1.4.0 release][pal-plat
 - [adding a new port to build system](pal-platform-newPort.md)
 
 
-[pal-platfrom-1-4-0-release]:https://github.com/ARMmbed/pal-platform/releases/tag/1.4.0
+[pal-platfrom-2-0-1-release]:https://github.com/ARMmbed/pal-platform/releases/tag/2.0.1

--- a/cloud-services/mbl-cloud-client/pal-platform/SDK/K64F_FreeRTOS/K64F_FreeRTOS.cmake
+++ b/cloud-services/mbl-cloud-client/pal-platform/SDK/K64F_FreeRTOS/K64F_FreeRTOS.cmake
@@ -1,12 +1,12 @@
 #################################################################################
 #  Copyright 2016, 2017 ARM Ltd.
-#
+#  
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
 #  You may obtain a copy of the License at
-#
+#  
 #      http://www.apache.org/licenses/LICENSE-2.0
-#
+#  
 #  Unless required by applicable law or agreed to in writing, software
 #  distributed under the License is distributed on an "AS IS" BASIS,
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -73,7 +73,7 @@ include_directories("${K64F_FREERTOS_FOLDER}/OS/FreeRTOS/${PAL_TARGET_OS}/Source
 set (EXTRA_CMAKE_DIRS ${EXTRA_CMAKE_DIRS} "${K64F_FREERTOS_FOLDER}/OS/FreeRTOS/${PAL_TARGET_OS}")
 if (${CPU} MATCHES "cortex-m4")
     if (CMAKE_C_COMPILER_ID STREQUAL "GNU")
-	include_directories("${K64F_FREERTOS_FOLDER}/OS/FreeRTOS/${PAL_TARGET_OS}/Source/portable/GCC/ARM_CM4F")
+    	include_directories("${K64F_FREERTOS_FOLDER}/OS/FreeRTOS/${PAL_TARGET_OS}/Source/portable/GCC/ARM_CM4F")
     elseif (CMAKE_C_COMPILER_ID STREQUAL "ARMCC")
         include_directories(${K64F_FREERTOS_FOLDER}/OS/FreeRTOS/${PAL_TARGET_OS}/Source/portable/RVDS/ARM_CM4F)
         SET_COMPILER_DBG_RLZ_FLAG(CMAKE_ASM_FLAGS "--cpu Cortex-M4.fp")
@@ -198,6 +198,6 @@ endif()
 
 	set (EXTRA_CMAKE_DIRS ${EXTRA_CMAKE_DIRS} "${K64F_FREERTOS_FOLDER}/Middleware/mmcau_2.0.0")
 	list (APPEND PLATFORM_LIBS mmcau_2.0.0)
-
+    
 
  # endif(CMAKE_BUILD_TYPE MATCHES Release) # comment end

--- a/cloud-services/mbl-cloud-client/pal-platform/SDK/K64F_FreeRTOS/K64F_FreeRTOS.patch
+++ b/cloud-services/mbl-cloud-client/pal-platform/SDK/K64F_FreeRTOS/K64F_FreeRTOS.patch
@@ -3,9 +3,9 @@ index 3e47224..166c5ae 100644
 --- a/K64F_FreeRTOS/Middleware/mbedtls/CMakeLists.txt
 +++ b/K64F_FreeRTOS/Middleware/mbedtls/CMakeLists.txt
 @@ -58,26 +58,27 @@ set(CMAKE_BUILD_TYPE ${CMAKE_BUILD_TYPE}
-
+ 
  string(REGEX MATCH "Clang" CMAKE_COMPILER_IS_CLANG "${CMAKE_C_COMPILER_ID}")
-
+ 
 -if(CMAKE_COMPILER_IS_GNUCC)
 -    # some warnings we want are not available with old GCC versions
 -    # note: starting with CMake 2.8 we could use CMAKE_C_COMPILER_VERSION
@@ -47,6 +47,6 @@ index 3e47224..166c5ae 100644
 +#    set(CMAKE_C_FLAGS_CHECK       "-Werror -Os")
 +#    set(CMAKE_C_FLAGS_CHECKFULL   "${CMAKE_C_FLAGS_CHECK} -Wcast-qual")
 +#endif(CMAKE_COMPILER_IS_GNUCC)
-
+ 
  if(CMAKE_COMPILER_IS_CLANG)
      set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -W -Wdeclaration-after-statement -Wwrite-strings -Wpointer-arith -Wimplicit-fallthrough -Wshadow")

--- a/cloud-services/mbl-cloud-client/pal-platform/Toolchain/ARMCC/ARMCC-ASM.cmake
+++ b/cloud-services/mbl-cloud-client/pal-platform/Toolchain/ARMCC/ARMCC-ASM.cmake
@@ -1,12 +1,12 @@
 #################################################################################
 #  Copyright 2016, 2017 ARM Ltd.
-#
+#  
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
 #  You may obtain a copy of the License at
-#
+#  
 #      http://www.apache.org/licenses/LICENSE-2.0
-#
+#  
 #  Unless required by applicable law or agreed to in writing, software
 #  distributed under the License is distributed on an "AS IS" BASIS,
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,3 +15,4 @@
 #################################################################################
 
 set(CMAKE_ASM_OUTPUT_EXTENSION ".o")
+

--- a/cloud-services/mbl-cloud-client/pal-platform/Toolchain/ARMCC/ARMCC-C.cmake
+++ b/cloud-services/mbl-cloud-client/pal-platform/Toolchain/ARMCC/ARMCC-C.cmake
@@ -1,12 +1,12 @@
 #################################################################################
 #  Copyright 2016, 2017 ARM Ltd.
-#
+#  
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
 #  You may obtain a copy of the License at
-#
+#  
 #      http://www.apache.org/licenses/LICENSE-2.0
-#
+#  
 #  Unless required by applicable law or agreed to in writing, software
 #  distributed under the License is distributed on an "AS IS" BASIS,
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/cloud-services/mbl-cloud-client/pal-platform/Toolchain/ARMCC/ARMCC-CXX.cmake
+++ b/cloud-services/mbl-cloud-client/pal-platform/Toolchain/ARMCC/ARMCC-CXX.cmake
@@ -1,12 +1,12 @@
 #################################################################################
 #  Copyright 2016, 2017 ARM Ltd.
-#
+#  
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
 #  You may obtain a copy of the License at
-#
+#  
 #      http://www.apache.org/licenses/LICENSE-2.0
-#
+#  
 #  Unless required by applicable law or agreed to in writing, software
 #  distributed under the License is distributed on an "AS IS" BASIS,
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/cloud-services/mbl-cloud-client/pal-platform/Toolchain/ARMCC/ARMCC-flags.cmake
+++ b/cloud-services/mbl-cloud-client/pal-platform/Toolchain/ARMCC/ARMCC-flags.cmake
@@ -1,12 +1,12 @@
 #################################################################################
 #  Copyright 2016, 2017 ARM Ltd.
-#
+#  
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
 #  You may obtain a copy of the License at
-#
+#  
 #      http://www.apache.org/licenses/LICENSE-2.0
-#
+#  
 #  Unless required by applicable law or agreed to in writing, software
 #  distributed under the License is distributed on an "AS IS" BASIS,
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/cloud-services/mbl-cloud-client/pal-platform/Toolchain/ARMCC/ARMCC.cmake
+++ b/cloud-services/mbl-cloud-client/pal-platform/Toolchain/ARMCC/ARMCC.cmake
@@ -1,12 +1,12 @@
 #################################################################################
 #  Copyright 2016, 2017 ARM Ltd.
-#
+#  
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
 #  You may obtain a copy of the License at
-#
+#  
 #      http://www.apache.org/licenses/LICENSE-2.0
-#
+#  
 #  Unless required by applicable law or agreed to in writing, software
 #  distributed under the License is distributed on an "AS IS" BASIS,
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/cloud-services/mbl-cloud-client/pal-platform/Toolchain/ARMGCC/ARMGCC-flags.cmake
+++ b/cloud-services/mbl-cloud-client/pal-platform/Toolchain/ARMGCC/ARMGCC-flags.cmake
@@ -1,12 +1,12 @@
 #################################################################################
 #  Copyright 2016, 2017 ARM Ltd.
-#
+#  
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
 #  You may obtain a copy of the License at
-#
+#  
 #      http://www.apache.org/licenses/LICENSE-2.0
-#
+#  
 #  Unless required by applicable law or agreed to in writing, software
 #  distributed under the License is distributed on an "AS IS" BASIS,
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/cloud-services/mbl-cloud-client/pal-platform/Toolchain/ARMGCC/ARMGCC.cmake
+++ b/cloud-services/mbl-cloud-client/pal-platform/Toolchain/ARMGCC/ARMGCC.cmake
@@ -1,12 +1,12 @@
 #################################################################################
 #  Copyright 2016, 2017 ARM Ltd.
-#
+#  
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
 #  You may obtain a copy of the License at
-#
+#  
 #      http://www.apache.org/licenses/LICENSE-2.0
-#
+#  
 #  Unless required by applicable law or agreed to in writing, software
 #  distributed under the License is distributed on an "AS IS" BASIS,
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/cloud-services/mbl-cloud-client/pal-platform/Toolchain/ARMGCC/armgcc_force_cpp.cmake
+++ b/cloud-services/mbl-cloud-client/pal-platform/Toolchain/ARMGCC/armgcc_force_cpp.cmake
@@ -1,12 +1,12 @@
 #################################################################################
 #  Copyright 2016, 2017 ARM Ltd.
-#
+#  
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
 #  You may obtain a copy of the License at
-#
+#  
 #      http://www.apache.org/licenses/LICENSE-2.0
-#
+#  
 #  Unless required by applicable law or agreed to in writing, software
 #  distributed under the License is distributed on an "AS IS" BASIS,
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/cloud-services/mbl-cloud-client/pal-platform/Toolchain/GCC-OPENWRT/GCC-OPENWRT-flags.cmake
+++ b/cloud-services/mbl-cloud-client/pal-platform/Toolchain/GCC-OPENWRT/GCC-OPENWRT-flags.cmake
@@ -1,12 +1,12 @@
 #################################################################################
 #  Copyright 2016, 2017 ARM Ltd.
-#
+#  
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
 #  You may obtain a copy of the License at
-#
+#  
 #      http://www.apache.org/licenses/LICENSE-2.0
-#
+#  
 #  Unless required by applicable law or agreed to in writing, software
 #  distributed under the License is distributed on an "AS IS" BASIS,
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -132,3 +132,4 @@ SET_COMPILER_DBG_RLZ_FLAG (CMAKE_EXE_LINKER_FLAGS "-mfloat-abi=softfp")
 #########
 
 MESSAGE(STATUS "BUILD_TYPE: " ${CMAKE_BUILD_TYPE})
+

--- a/cloud-services/mbl-cloud-client/pal-platform/Toolchain/GCC-OPENWRT/GCC-OPENWRT.cmake
+++ b/cloud-services/mbl-cloud-client/pal-platform/Toolchain/GCC-OPENWRT/GCC-OPENWRT.cmake
@@ -1,12 +1,12 @@
 #################################################################################
 #  Copyright 2016, 2017 ARM Ltd.
-#
+#  
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
 #  You may obtain a copy of the License at
-#
+#  
 #      http://www.apache.org/licenses/LICENSE-2.0
-#
+#  
 #  Unless required by applicable law or agreed to in writing, software
 #  distributed under the License is distributed on an "AS IS" BASIS,
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -85,3 +85,4 @@ SET(TOOLCHAIN_FLAGS_FILE "${CMAKE_SOURCE_DIR}/../pal-platform/Toolchain/GCC-OPEN
 
 
 MESSAGE(STATUS "BUILD_TYPE: " ${CMAKE_BUILD_TYPE})
+

--- a/cloud-services/mbl-cloud-client/pal-platform/Toolchain/GCC/GCC-flags.cmake
+++ b/cloud-services/mbl-cloud-client/pal-platform/Toolchain/GCC/GCC-flags.cmake
@@ -1,12 +1,12 @@
 #################################################################################
 #  Copyright 2016-2018 ARM Ltd.
-#
+#  
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
 #  You may obtain a copy of the License at
-#
+#  
 #      http://www.apache.org/licenses/LICENSE-2.0
-#
+#  
 #  Unless required by applicable law or agreed to in writing, software
 #  distributed under the License is distributed on an "AS IS" BASIS,
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -103,7 +103,7 @@ endif ()
 if (${CPU} MATCHES "x86_64")
     SET_COMPILER_DBG_RLZ_FLAG (CMAKE_EXE_LINKER_FLAGS "-m32")
 elseif (${CPU} MATCHES "cortex-m4")
-    SET_COMPILER_DBG_RLZ_FLAG (CMAKE_EXE_LINKER_FLAGS "-mcpu=${CPU}")
+    SET_COMPILER_DBG_RLZ_FLAG (CMAKE_EXE_LINKER_FLAGS "-mcpu=${CPU}")     
     SET_COMPILER_DBG_RLZ_FLAG (CMAKE_EXE_LINKER_FLAGS "-mfloat-abi=hard")
     SET_COMPILER_DBG_RLZ_FLAG (CMAKE_EXE_LINKER_FLAGS "--specs=nano.specs")
     SET_COMPILER_DBG_RLZ_FLAG (CMAKE_EXE_LINKER_FLAGS "-mthumb")

--- a/cloud-services/mbl-cloud-client/pal-platform/Toolchain/GCC/GCC.cmake
+++ b/cloud-services/mbl-cloud-client/pal-platform/Toolchain/GCC/GCC.cmake
@@ -1,13 +1,13 @@
 
 #################################################################################
 #  Copyright 2016-2018 ARM Ltd.
-#
+#  
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
 #  You may obtain a copy of the License at
-#
+#  
 #      http://www.apache.org/licenses/LICENSE-2.0
-#
+#  
 #  Unless required by applicable law or agreed to in writing, software
 #  distributed under the License is distributed on an "AS IS" BASIS,
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -64,7 +64,7 @@ SET(CMAKE_OBJCOPY ${TOOLCHAIN_BIN_DIR}/objcopy CACHE INTERNAL "objcopy tool")
 SET(CMAKE_OBJDUMP ${TOOLCHAIN_BIN_DIR}/objdump CACHE INTERNAL "objdump tool")
 
 SET(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -O3 " CACHE INTERNAL "c compiler flags release")
-SET(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3 " CACHE INTERNAL "cxx compiler flags release")
+SET(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3 " CACHE INTERNAL "cxx compiler flags release")   
 SET(CMAKE_ASM_FLAGS_RELEASE "${CMAKE_ASM_FLAGS_RELEASE}" CACHE INTERNAL "asm compiler flags release")
 SET(CMAKE_EXE_LINKER_FLAGS_RELESE "${CMAKE_EXE_LINKER_FLAGS_RELESE}" CACHE INTERNAL "linker flags release")
 
@@ -91,3 +91,4 @@ SET(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY BOTH)
 SET(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE BOTH)
 
 MESSAGE(STATUS "BUILD_TYPE: " ${CMAKE_BUILD_TYPE})
+

--- a/cloud-services/mbl-cloud-client/pal-platform/Toolchain/POKY-GLIBC/POKY-GLIBC-flags.cmake
+++ b/cloud-services/mbl-cloud-client/pal-platform/Toolchain/POKY-GLIBC/POKY-GLIBC-flags.cmake
@@ -1,13 +1,13 @@
 
 #################################################################################
 #  Copyright 2016, 2017 ARM Ltd.
-#
+#  
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
 #  You may obtain a copy of the License at
-#
+#  
 #      http://www.apache.org/licenses/LICENSE-2.0
-#
+#  
 #  Unless required by applicable law or agreed to in writing, software
 #  distributed under the License is distributed on an "AS IS" BASIS,
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/cloud-services/mbl-cloud-client/pal-platform/Toolchain/POKY-GLIBC/POKY-GLIBC.cmake
+++ b/cloud-services/mbl-cloud-client/pal-platform/Toolchain/POKY-GLIBC/POKY-GLIBC.cmake
@@ -1,13 +1,13 @@
 
 #################################################################################
 #  Copyright 2016, 2017 ARM Ltd.
-#
+#  
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
 #  You may obtain a copy of the License at
-#
+#  
 #      http://www.apache.org/licenses/LICENSE-2.0
-#
+#  
 #  Unless required by applicable law or agreed to in writing, software
 #  distributed under the License is distributed on an "AS IS" BASIS,
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/cloud-services/mbl-cloud-client/pal-platform/common.cmake
+++ b/cloud-services/mbl-cloud-client/pal-platform/common.cmake
@@ -1,12 +1,12 @@
 #################################################################################
 #  Copyright 2016, 2017 ARM Ltd.
-#
+#  
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
 #  You may obtain a copy of the License at
-#
+#  
 #      http://www.apache.org/licenses/LICENSE-2.0
-#
+#  
 #  Unless required by applicable law or agreed to in writing, software
 #  distributed under the License is distributed on an "AS IS" BASIS,
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/cloud-services/mbl-cloud-client/pal-platform/mbedCloudClientCmake.txt
+++ b/cloud-services/mbl-cloud-client/pal-platform/mbedCloudClientCmake.txt
@@ -1,12 +1,12 @@
 #################################################################################
 #  Copyright 2016-2018 ARM Ltd.
-#
+#  
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
 #  You may obtain a copy of the License at
-#
+#  
 #      http://www.apache.org/licenses/LICENSE-2.0
-#
+#  
 #  Unless required by applicable law or agreed to in writing, software
 #  distributed under the License is distributed on an "AS IS" BASIS,
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -161,3 +161,5 @@ endforeach()
 
 UNSET(CMAKE_TOOLCHAIN_FILE_CONFIGURED CACHE)
 UNSET(CMAKE_TOOLCHAIN_FILE_CONFIGURED)
+
+

--- a/cloud-services/mbl-cloud-client/pal-platform/pal-platform-buildSystem.md
+++ b/cloud-services/mbl-cloud-client/pal-platform/pal-platform-buildSystem.md
@@ -15,7 +15,7 @@ The sources for the build system macros is located in [common.cmake](./common.cm
 4. ADD_GLOBALDIR(dir_name) - This macro adds a directory "dir_name"  to the include path for all the components. The macro writes the directory inside a file with '-I', the file is added to the C and CXX flags in the toolchain-flags files. [See example GCC-flags file.](Toolchain/GCC/GCC-flags.cmake#L148-#L153)
 
 ## How to use the Build system.
-After deploying the relevant target using the [pal-platform util](./pal-platform-util.md) you will have a new directory named "__targetName" inside this directory there will be a CMakeFile.txt which is actually [mbedCloudClientCmake.txt](./mbedCloudClientCmake.txt). This file gathers all the libraries created by CREATE_LIBRARY and links them with the each of the CREATE_TEST_LIBRARY to create a binary file.
+After deploying the relevant target using the [pal-platform util](./pal-platform-util.md) you will have a new directory named "__targetName" inside this directory there will be a CMakeFile.txt which is actually [mbedCloudClientCmake.txt](./mbedCloudClientCmake.txt). This file gathers all the libraries created by CREATE_LIBRARY and links them with the each of the CREATE_TEST_LIBRARY to create a binary file. 
 Each CMakeLists.txt file needs to call ADDSUBDIRS macro to include his child directories.
 
 Please view  [mbed-client-pal](https://github.com/ARMmbed/mbed-client-pal) repository for example:
@@ -23,3 +23,4 @@ Please view  [mbed-client-pal](https://github.com/ARMmbed/mbed-client-pal) repos
  2. source [CMakeLists.txt](https://github.com/ARMmbed/mbed-client-pal/blob/master/Source/CMakeLists.txt) file
  3. Tests [CMakeLists.txt](https://github.com/ARMmbed/mbed-client-pal/blob/master/Test/CMakeLists.txt) file
 
+ 

--- a/cloud-services/mbl-cloud-client/pal-platform/pal-platform-newPort.md
+++ b/cloud-services/mbl-cloud-client/pal-platform/pal-platform-newPort.md
@@ -14,20 +14,20 @@ For the full build option you will need to update the toolchain lookup table at 
 
 ### Adding Toolchain configurations
 Adding a new toolchain requires the creation of a new folder containing two files:
-1.  Toolchain - a file with basic configurations for the toolcahin.
+1.  Toolchain - a file with basic configurations for the toolcahin. 
     For example please view [GCC file](./Toolchain/GCC/GCC.cmake)
 2.  Flags file - a file that contains all the compilation flags for this specific Toolchain
     For example please view [GCC Flags file](./Toolchain/GCC/GCC-flags.cmake)
 
 `Please Note`
-1. The value of TOOLCHAIN_FLAGS_FILE inside the Toolchain file must be set to the toolchain flags file.
+1. The value of TOOLCHAIN_FLAGS_FILE inside the Toolchain file must be set to the toolchain flags file. 
 See example inside the GCC toolchain file: https://github.com/ARMmbed/pal-platform/blob/master/Toolchain/GCC/GCC.cmake#L82
 
 2. The flags file must contain an include to include.txt file for the ADD_GLOBALDIR CMake macro to work.
-See example inside the GCC-flags toolchain file:
+See example inside the GCC-flags toolchain file: 
 https://github.com/ARMmbed/pal-platform/blob/master/Toolchain/GCC/GCC-flags.cmake#L150-L153
 
-### Adding CMake files to platform
+### Adding CMake files to platform 
 
 Every component added to the pal-platfrom should have its own cmake file. It does not matter if this is a SDK, Device or middleware.
 

--- a/cloud-services/mbl-cloud-client/pal-platform/pal-platform.json
+++ b/cloud-services/mbl-cloud-client/pal-platform/pal-platform.json
@@ -49,11 +49,11 @@
     },
     "middleware": {
       "mbedtls": {
-        "version": "2.10.0",
+        "version": "2.13.1",
         "from": {
           "protocol": "git",
           "location": "https://github.com/ARMmbed/mbedtls.git",
-          "tag": "mbedtls-2.10.0"
+          "tag": "mbedtls-2.13.1"
         },
         "to": "Middleware/mbedtls/mbedtls"
       }
@@ -70,11 +70,11 @@
     },
     "middleware": {
       "mbedtls": {
-        "version": "2.10.0",
+        "version": "2.13.1",
         "from": {
           "protocol": "git",
           "location": "https://github.com/ARMmbed/mbedtls.git",
-          "tag": "mbedtls-2.10.0"
+          "tag": "mbedtls-2.13.1"
         },
         "to": "Middleware/mbedtls/mbedtls"
       }
@@ -90,11 +90,11 @@
     },
     "middleware": {
       "mbedtls": {
-        "version": "2.10.0",
+        "version": "2.13.1",
         "from": {
           "protocol": "git",
           "location": "https://github.com/ARMmbed/mbedtls.git",
-          "tag": "mbedtls-2.10.0"
+          "tag": "mbedtls-2.13.1"
         },
         "to": "Middleware/mbedtls/mbedtls"
       }

--- a/cloud-services/mbl-cloud-client/pal-platform/pal-platform.py
+++ b/cloud-services/mbl-cloud-client/pal-platform/pal-platform.py
@@ -389,7 +389,7 @@ def check_cmd_and_raise(cmd, **kwargs):
     logger.debug(" ".join(cmd))
 
     subprocess.check_call(cmd, **kwargs)
-
+    
 def check_cmd(cmd, **kwargs):
     """
     Wrapper function for subprocess.check_call

--- a/cloud-services/mbl-cloud-client/pal-platform/platform.cmake
+++ b/cloud-services/mbl-cloud-client/pal-platform/platform.cmake
@@ -1,12 +1,12 @@
 #################################################################################
 #  Copyright 2016, 2017 ARM Ltd.
-#
+#  
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
 #  You may obtain a copy of the License at
-#
+#  
 #      http://www.apache.org/licenses/LICENSE-2.0
-#
+#  
 #  Unless required by applicable law or agreed to in writing, software
 #  distributed under the License is distributed on an "AS IS" BASIS,
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/cloud-services/mbl-cloud-client/source/MblError.cpp
+++ b/cloud-services/mbl-cloud-client/source/MblError.cpp
@@ -61,6 +61,10 @@ const char* MblError_to_str(const MblError error)
         case Error::UpdateErrorUserActionRequired: return "UpdateErrorUserActionRequired";
         case Error::UpdateFatalRebootRequired: return "UpdateFatalRebootRequired";
         case Error::UpdateErrorInvalidHash: return "UpdateErrorInvalidHash";
+
+        case Error::EnrollmentErrorBase: return "EnrollmentErrorBase";
+        case Error::EnrollmentErrorEnd: return "EnrollmentErrorEnd";
+
     }
     return "Unrecognized error code";
 }
@@ -100,6 +104,9 @@ MblError CloudClientError_to_MblError(MbedCloudClient::Error error)
         case MbedCloudClient::UpdateErrorUserActionRequired: return Error::UpdateErrorUserActionRequired;
         case MbedCloudClient::UpdateFatalRebootRequired: return Error::UpdateFatalRebootRequired;
         case MbedCloudClient::UpdateErrorInvalidHash: return Error::UpdateErrorInvalidHash;
+    
+        case MbedCloudClient::EnrollmentErrorBase: return Error::EnrollmentErrorBase;
+        case MbedCloudClient::EnrollmentErrorEnd: return Error::EnrollmentErrorEnd;
     }
     return Error::Unknown;
 }

--- a/cloud-services/mbl-cloud-client/source/MblError.h
+++ b/cloud-services/mbl-cloud-client/source/MblError.h
@@ -62,7 +62,11 @@ enum Type {
     UpdateWarningNoActionRequired       = 0x020b,
     UpdateErrorUserActionRequired       = 0x020c,
     UpdateFatalRebootRequired           = 0x020d,
-    UpdateErrorInvalidHash              = 0x020e
+    UpdateErrorInvalidHash              = 0x020e,
+
+    EnrollmentErrorBase                 = 0x0300,
+    EnrollmentErrorEnd                  = 0x0301
+
 };
 } // namespace Error
 

--- a/cloud-services/mbl-cloud-client/source/callbacks.cpp
+++ b/cloud-services/mbl-cloud-client/source/callbacks.cpp
@@ -29,10 +29,10 @@ void pal_plat_osApplicationReboot(void)
     if (fp != NULL)
     {
         fclose (fp);
-        PAL_LOG(INFO, "Not rebooting the system (application update)\r\n");
+        PAL_LOG_INFO("Not rebooting the system (application update)\r\n");
         return;
     }
     
-    PAL_LOG(INFO, "Rebooting the system\r\n");
+    PAL_LOG_INFO("Rebooting the system\r\n");
     pal_plat_osReboot();
 }


### PR DESCRIPTION
The reason: the previous version of mbed-cloud-client (1.4.0) would be incompatible in future with the version of Cloud Services(Pelion). The version of PAL is also updated to 2.0.1. Jira: IOTMBL-952

> Connected PR's: https://github.com/ARMmbed/mbl-core/pull/28

Signed-off-by: MaximAxelrod <maxim.axelrod@arm.com>