### PR TITLE
Fix mbl-app-update-manager exit status

### DIFF
--- a/firmware-management/mbl-app-update-manager/mbl/app_update_manager/cli.py
+++ b/firmware-management/mbl-app-update-manager/mbl/app_update_manager/cli.py
@@ -85,15 +85,15 @@ def _main():
                 e.returncode
             )
         )
-        return aupm.Error.ERR_OPERATION_FAILED
+        return aupm.Error.ERR_OPERATION_FAILED.value
     except OSError:
         logger.exception("Operation failed with OSError")
-        return aupm.Error.ERR_OPERATION_FAILED
+        return aupm.Error.ERR_OPERATION_FAILED.value
     except Exception:
         logger.exception("Operation failed exception")
-        return aupm.Error.ERR_OPERATION_FAILED
+        return aupm.Error.ERR_OPERATION_FAILED.value
     if ret == aupm.Error.SUCCESS:
         logger.info("Operation successful")
     else:
         logger.error("Operation failed: {}".format(ret))
-    return ret
+    return ret.value


### PR DESCRIPTION
For: IOTMBL-1014: mbl-app-update-manager never exits successfully.

firmware-management/mbl-app-update-manager/mbl/app_update_manager/cli.py:
* _main should return integers, not enum values.