### PR TITLE
Remove requirements.txt file for rng test

### DIFF
--- a/mbl-core/tests/devices/random/requirements.txt
+++ b/mbl-core/tests/devices/random/requirements.txt
@@ -1,5 +1,0 @@
-sys
-subprocess
-os
-gzip
-tempfile


### PR DESCRIPTION
All required packages are built in Python3 and not downloadable with pip.