### PR TITLE
Divide CloudConnectStatus to ranges

### DIFF
--- a/cloud-services/mbl-cloud-client/source/cloud-connect-resource-broker/CloudConnectExternalTypes.h
+++ b/cloud-services/mbl-cloud-client/source/cloud-connect-resource-broker/CloudConnectExternalTypes.h
@@ -13,9 +13,13 @@ extern "C" {
  * @brief Status of Cloud Connect operations.
  */
 enum CloudConnectStatus {
-    SUCCESS = 0x0000, 
-    FAILED  = 0x0001,
+    // Status range (non error statuses)
+    // Start all enums in status range with "STATUS_" prefix
+    STATUS_SUCCESS = 0x0000, 
 
+    // Error range
+    // Start all enums in this range with "ERR_" prefix
+    ERR_FAILED  = 0x1000,
 };
  
 typedef enum CloudConnectStatus CloudConnectStatus;

--- a/cloud-services/mbl-cloud-client/source/cloud-connect-resource-broker/CloudConnectTypes.cpp
+++ b/cloud-services/mbl-cloud-client/source/cloud-connect-resource-broker/CloudConnectTypes.cpp
@@ -87,14 +87,14 @@ const char* CloudConnectStatus_to_readable_string(const CloudConnectStatus statu
 {
     switch (status)
     {
-        case SUCCESS: 
-            return "SUCCESS";
+        case STATUS_SUCCESS: 
+            return "STATUS SUCCESS";
 
-        case FAILED: 
-            return "FAILED";
+        case ERR_FAILED: 
+            return "ERROR FAILED";
 
         default:
-            return "Unknown Cloud Connect Status";
+            return "Unknown Cloud Connect Status or Error";
     }
 }
 
@@ -102,11 +102,11 @@ const char* CloudConnectStatus_stringify(const CloudConnectStatus status)
 {
     switch (status)
     {
-        RETURN_STRINGIFIED_VALUE(SUCCESS); 
-        RETURN_STRINGIFIED_VALUE(FAILED); 
+        RETURN_STRINGIFIED_VALUE(STATUS_SUCCESS); 
+        RETURN_STRINGIFIED_VALUE(ERR_FAILED); 
 
         default:
-            return "Unknown Cloud Connect Status";
+            return "Unknown CloudConnectStatus value";
     }
 }
 

--- a/cloud-services/mbl-cloud-client/source/cloud-connect-resource-broker/CloudConnectTypes.h
+++ b/cloud-services/mbl-cloud-client/source/cloud-connect-resource-broker/CloudConnectTypes.h
@@ -119,7 +119,7 @@ struct ResourceSetOperation
     {}
 
     const ResourceData input_data_; // set operation input data
-    CloudConnectStatus output_status_ = FAILED; // set operation output status
+    CloudConnectStatus output_status_ = ERR_FAILED; // set operation output status
 };
 
 struct ResourceGetOperation
@@ -136,7 +136,7 @@ struct ResourceGetOperation
     {}
 
     ResourceData inout_data_;// get operation input and output data
-    CloudConnectStatus output_status_ = FAILED; // get operation output status
+    CloudConnectStatus output_status_ = ERR_FAILED; // get operation output status
 };
 
 /**


### PR DESCRIPTION
Required to divide CloudConnectStatus to ranges: status and error - in order to make application notifications more clear.


