### PR TITLE
Change the reference to AppStopTimeoutError

### DIFF
--- a/firmware-management/mbl-app-update-manager/mbl/app_update_manager/manager.py
+++ b/firmware-management/mbl-app-update-manager/mbl/app_update_manager/manager.py
@@ -28,7 +28,7 @@ ROLLBACK_EXCEPTIONS = (
     alc.ContainerDeleteError,
     apm.AppPathInexistent,
     apm.AppUninstallError,
-    apm.AppStopTimeoutError,
+    alm.AppStopTimeoutError,
     alc.ContainerCreationError,
     alc.ContainerStartError,
 )
@@ -270,7 +270,7 @@ class AppUpdateManager:
             except (
                 alc.ContainerKillError,
                 alc.ContainerDeleteError,
-                apm.AppStopTimeoutError,
+                alm.AppStopTimeoutError,
             ) as terminate_error:
                 log.error(
                     "Rollback applications as failed"
@@ -291,7 +291,7 @@ class AppUpdateManager:
             except (
                 alc.ContainerKillError,
                 alc.ContainerDeleteError,
-                apm.AppStopTimeoutError,
+                alm.AppStopTimeoutError,
             ) as terminate_error:
                 if alc.ContainerState.DOES_NOT_EXIST.value in str(
                     terminate_error


### PR DESCRIPTION
The AppStopTimeoutError exception is defined in the
app-lifecycle-manager, not the app manager.

Changed all references to apm.AppStopTimeoutError to
alm.AppStopTimeoutError