### PR TITLE
Don't instantly return if an item we attempt to delete can't be found

### DIFF
--- a/cloud-services/mbl-cloud-client/cloud-provisioning/provisioning.cpp
+++ b/cloud-services/mbl-cloud-client/cloud-provisioning/provisioning.cpp
@@ -252,7 +252,7 @@ namespace mbl {
                                                                item.name.size(),
                                                                item.type);
 
-                if (kcm_delete_status != KCM_STATUS_SUCCESS || kcm_delete_status != KCM_STATUS_ITEM_NOT_FOUND)
+                if (kcm_delete_status != KCM_STATUS_SUCCESS && kcm_delete_status != KCM_STATUS_ITEM_NOT_FOUND)
                 {
                     print_kcm_error_status(std::cerr,
                                            "Failed to delete KCM Item! Item name: " + item.name,


### PR DESCRIPTION
If a device has a newly flashed image, there are obviously no preexisting certificates to delete from ESFS. So do not return early if KCM returns `KCM_STATUS_ITEM_NOT_FOUND`