### PR TITLE
Aba mbl core iotmbl 1496

### DIFF
--- a/cloud-services/mbl-cloud-client/.vscode/settings.json
+++ b/cloud-services/mbl-cloud-client/.vscode/settings.json
@@ -51,6 +51,9 @@
         "typeinfo": "cpp",
         "utility": "cpp",
         "cmath": "cpp",
-        "numeric": "cpp"
+        "numeric": "cpp",
+        "chrono": "cpp",
+        "cstddef": "cpp",
+        "ratio": "cpp"
     }
 }

--- a/cloud-services/mbl-cloud-client/source/MblError.cpp
+++ b/cloud-services/mbl-cloud-client/source/MblError.cpp
@@ -71,6 +71,8 @@ const char* MblError_to_str(const MblError error)
     case Error::CCRBCreateM2MObjFailed: return "CCRBCreateM2MObjFailed";
     case Error::CCRBValueTypeError: return "CCRBValueTypeError";
     case Error::CCRBGenerateUniqueIdFailed: return "CCRBGenerateUniqueIdFailed";
+    case Error::CCRBInvalidResourcePath: return "CCRBInvalidResourcePath";
+    case Error::CCRBResourceNotFound: return "CCRBResourceNotFound";
     case Error::DBA_IllegalState: return "DBA_IllegalState";
     case Error::DBA_InvalidValue: return "DBA_InvalidValue";
     case Error::DBA_ForbiddenCall: return "DBA_ForbiddenCall";

--- a/cloud-services/mbl-cloud-client/source/MblError.h
+++ b/cloud-services/mbl-cloud-client/source/MblError.h
@@ -76,6 +76,8 @@ enum Type {
     CCRBCreateM2MObjFailed              = 0x0404,
     CCRBValueTypeError                  = 0x0405,
     CCRBGenerateUniqueIdFailed          = 0x0406,
+    CCRBInvalidResourcePath             = 0x0407,
+    CCRBResourceNotFound                = 0x0408,
 		
     // DBA (D-Bus Adapter) errors
     DBA_IllegalState                    = 0x0500,

--- a/cloud-services/mbl-cloud-client/source/cloud-connect-resource-broker/CloudConnectExternalTypes.h
+++ b/cloud-services/mbl-cloud-client/source/cloud-connect-resource-broker/CloudConnectExternalTypes.h
@@ -32,7 +32,10 @@ enum CloudConnectStatus {
     ERR_INVALID_APPLICATION_RESOURCES_DEFINITION    = 0x1001,
     ERR_REGISTRATION_ALREADY_IN_PROGRESS            = 0x1002,
     ERR_ALREADY_REGISTERED                          = 0x1003,
-
+    ERR_INVALID_ACCESS_TOKEN                        = 0x1004,
+    ERR_INVALID_RESOURCE_PATH                       = 0x1005,
+    ERR_RESOURCE_NOT_FOUND                          = 0x1006,
+    ERR_INVALID_RESOURCE_TYPE                       = 0x1007,
 };
  
 typedef enum CloudConnectStatus CloudConnectStatus;
@@ -50,6 +53,10 @@ static inline bool is_CloudConnectStatus_error(const CloudConnectStatus val){
 #define CLOUD_CONNECT_ERR_INVALID_APPLICATION_RESOURCES_DEFINITION "mbed.Cloud.Connect.Error.InvalidApplicationResourceDefinition"
 #define CLOUD_CONNECT_ERR_REGISTRATION_ALREADY_IN_PROGRESS "mbed.Cloud.Connect.Error.RegistrationAlreadyInProgress"
 #define CLOUD_CONNECT_ERR_ALREADY_REGISTERED "mbed.Cloud.Connect.Error.AlreadyRegistered"
+#define CLOUD_CONNECT_ERR_INVALID_ACCESS_TOKEN "mbed.Cloud.Connect.Error.InvalidAccessToken"
+#define CLOUD_CONNECT_ERR_INVALID_RESOURCE_PATH "mbed.Cloud.Connect.Error.InvalidResourcePath"
+#define CLOUD_CONNECT_ERR_RESOURCE_NOT_FOUND "mbed.Cloud.Connect.Error.ResourceNotFound"
+#define CLOUD_CONNECT_ERR_INVALID_RESOURCE_TYPE "mbed.Cloud.Connect.Error.InvalidResourceType"
 
 /** 
  * @brief Returns corresponding D-Bus format error. 

--- a/cloud-services/mbl-cloud-client/source/cloud-connect-resource-broker/CloudConnectTypes.cpp
+++ b/cloud-services/mbl-cloud-client/source/cloud-connect-resource-broker/CloudConnectTypes.cpp
@@ -97,6 +97,10 @@ const char* CloudConnectStatus_to_readable_str(const CloudConnectStatus status)
         return "Invalid application resource definition";
     case ERR_REGISTRATION_ALREADY_IN_PROGRESS: return "Registration already in progress";
     case ERR_ALREADY_REGISTERED: return "Already registered";
+    case ERR_INVALID_ACCESS_TOKEN: return "Invalid access token";
+    case ERR_INVALID_RESOURCE_PATH: return "Invalid resource path";
+    case ERR_RESOURCE_NOT_FOUND: return "Resource not found";
+    case ERR_INVALID_RESOURCE_TYPE: return "Invalid resource type";
 
     default: return "Unknown Cloud Connect Status or Error";
     }
@@ -110,6 +114,10 @@ const char* CloudConnectStatus_error_to_DBus_format_str(const CloudConnectStatus
         RETURN_DBUS_FORMAT_ERROR(ERR_INVALID_APPLICATION_RESOURCES_DEFINITION);
         RETURN_DBUS_FORMAT_ERROR(ERR_REGISTRATION_ALREADY_IN_PROGRESS);
         RETURN_DBUS_FORMAT_ERROR(ERR_ALREADY_REGISTERED);
+        RETURN_DBUS_FORMAT_ERROR(ERR_INVALID_ACCESS_TOKEN);
+        RETURN_DBUS_FORMAT_ERROR(ERR_INVALID_RESOURCE_PATH);
+        RETURN_DBUS_FORMAT_ERROR(ERR_RESOURCE_NOT_FOUND);
+        RETURN_DBUS_FORMAT_ERROR(ERR_INVALID_RESOURCE_TYPE);
 
     default: return "Unknown CloudConnectStatus value";
     }

--- a/cloud-services/mbl-cloud-client/source/cloud-connect-resource-broker/RegistrationRecord.cpp
+++ b/cloud-services/mbl-cloud-client/source/cloud-connect-resource-broker/RegistrationRecord.cpp
@@ -20,6 +20,19 @@
 #include "ResourceDefinitionParser.h"
 #include "mbed-cloud-client/MbedCloudClient.h"
 
+#include <algorithm>
+
+#define PATH_SEPERATOR '/'
+
+// In case of object/object_instance,resource - depth is 3
+// In case of object/object_instance,resource/resource_instance - depth is 4
+static const size_t RESOURCE_DEPTH = 3;
+static const size_t RESOURCE_INSTANCE_DEPTH = 4;
+static uint8_t OBJECT_INDEX = 0;
+static uint8_t OBJECT_INSTANCE_INDEX = 1;
+static uint8_t RESOURCE_INDEX = 2;
+static uint8_t RESOURCE_INSTANCE_INDEX = 3;
+
 #define TRACE_GROUP "ccrb-registration-record"
 
 namespace mbl
@@ -41,15 +54,168 @@ MblError RegistrationRecord::init(const std::string& application_resource_defini
     TR_DEBUG("Enter");
 
     // Parse JSON
-    const MblError build_object_list_stauts = ResourceDefinitionParser::build_object_list(
-        application_resource_definition, m2m_object_list_);
+    std::pair<MblError, M2MObjectList> ret_pair =
+        ResourceDefinitionParser::build_object_list(application_resource_definition);
 
-    if (Error::None != build_object_list_stauts) {
-        TR_ERR("build_object_list failed with error: %s",
-               MblError_to_str(build_object_list_stauts));
-        return build_object_list_stauts;
+    if (Error::None != ret_pair.first) {
+        TR_ERR("build_object_list failed with error: %s", MblError_to_str(ret_pair.first));
+        return ret_pair.first;
+    }
+
+    m2m_object_list_ = ret_pair.second;
+    return Error::None;
+}
+
+MblError RegistrationRecord::get_resource_identifiers(const std::string& path,
+                                                      std::string& out_object_name,
+                                                      uint16_t& out_object_instance_id,
+                                                      std::string& out_resource_name,
+                                                      std::string& out_resource_instance_name)
+{
+    TR_DEBUG("Enter");
+
+    std::size_t current_pos = path.find_first_of(PATH_SEPERATOR);
+
+    // Make sure path starts with "/"
+    if (0 != current_pos) {
+        TR_ERR("Invalid path: %s, should start with '/'", path.c_str());
+        return Error::CCRBInvalidResourcePath;
+    }
+
+    std::size_t last_pos = path.find_last_of(PATH_SEPERATOR);
+    if(last_pos == path.length() - 1) {
+        TR_ERR("Invalid path: %s, should end with '/'", path.c_str());
+        return Error::CCRBInvalidResourcePath;
+    }
+    
+
+    // Split all identifiers by path seperator and push into resource_identifiers vector
+    std::string substr;
+    std::size_t previous_pos = 0;
+    std::vector<std::string> resource_identifiers;
+    while (current_pos != std::string::npos) {
+        substr = path.substr(previous_pos, current_pos - previous_pos);
+        if (!substr.empty()) {
+            resource_identifiers.push_back(substr);
+        }
+        previous_pos = current_pos + 1;
+        current_pos = path.find_first_of(PATH_SEPERATOR, previous_pos);
+        if(current_pos == previous_pos) {
+            TR_ERR("Invalid path: %s, Two subsequent '/' are not allowed", path.c_str());
+            return Error::CCRBInvalidResourcePath;
+        }
+    }
+    resource_identifiers.push_back(path.substr(previous_pos, current_pos - previous_pos));
+
+    // In case of object/object_instance,resource - depth is 3
+    // In case of object/object_instance,resource/resource_instance - depth is 4
+    if ((resource_identifiers.size() < RESOURCE_DEPTH) || (resource_identifiers.size() > RESOURCE_INSTANCE_DEPTH)) {
+        TR_ERR("Invalid path: %s, depth = %d", path.c_str(), (int) resource_identifiers.size());
+        return Error::CCRBInvalidResourcePath;
+    }
+
+    // Object:
+    out_object_name = resource_identifiers[OBJECT_INDEX];
+    TR_DEBUG("object_name: %s", out_object_name.c_str());
+
+    // Object instance:
+    bool is_digit =
+        std::all_of(resource_identifiers[1].begin(), resource_identifiers[1].end(), ::isdigit);
+    if (!is_digit) {
+        TR_ERR("Invalid path: %s, object instance id: %s is not a number",
+               path.c_str(),
+               resource_identifiers[OBJECT_INSTANCE_INDEX].c_str());
+        return Error::CCRBInvalidResourcePath;
+    }
+    int object_instance_id = 0;
+    try
+    {
+        object_instance_id = std::stoi(resource_identifiers[OBJECT_INSTANCE_INDEX]);
+    } catch (std::out_of_range& e)
+    {
+        TR_ERR("Invalid path: %s, out_of_range object instance id value: %s",
+               path.c_str(),
+               resource_identifiers[OBJECT_INSTANCE_INDEX].c_str());
+        return Error::CCRBInvalidResourcePath;
+    } catch (std::invalid_argument& e)
+    {
+        TR_ERR("Invalid path: %s, invalid argument instance id value: %s",
+               path.c_str(),
+               resource_identifiers[OBJECT_INSTANCE_INDEX].c_str());
+        return Error::CCRBInvalidResourcePath;        
+    }
+    if (object_instance_id < 0 || object_instance_id > UINT16_MAX) {
+        TR_ERR("Invalid path %s, object_instance_id allowed value should be between 0 and %d",
+               path.c_str(),
+               UINT16_MAX);
+        return Error::CCRBInvalidResourcePath;
+    }
+    out_object_instance_id = static_cast<uint16_t>(object_instance_id);
+    TR_DEBUG("object_instance_id: %d", object_instance_id);
+
+    // Resource:
+    out_resource_name = resource_identifiers[RESOURCE_INDEX];
+    TR_DEBUG("resource_name: %s", out_resource_name.c_str());
+
+    // Resource instance:
+    if (resource_identifiers.size() == RESOURCE_INSTANCE_DEPTH) {
+        out_resource_instance_name = resource_identifiers[RESOURCE_INSTANCE_INDEX];
+        TR_DEBUG("resource_instance_name: %s", out_resource_instance_name.c_str());
     }
     return Error::None;
+}
+
+std::pair<MblError, M2MResource*> RegistrationRecord::get_m2m_resource(const std::string& path)
+{
+    TR_DEBUG("path: %s", path.c_str());
+
+    std::pair<MblError, M2MResource*> ret_pair(MblError::None, nullptr);
+
+    std::string object_name, resource_name, resource_instance_name;
+    uint16_t object_instance_id = 0;
+    const MblError status = get_resource_identifiers(
+        path, object_name, object_instance_id, resource_name, resource_instance_name);
+    if (Error::None != status) {
+        TR_ERR("get_resource_identifiers failed with error: %s", MblError_to_str(status));
+        ret_pair.first = status;
+        return ret_pair;
+    }
+
+    // TODO: Remove next check when we will support resource instances
+    if (!resource_instance_name.empty()) {
+        TR_ERR("Resource instances are not supported (%s)", path.c_str());
+        ret_pair.first = MblError::CCRBInvalidResourcePath;
+        return ret_pair;
+    }
+
+    M2MResource* m2m_resource = nullptr;
+    for (auto& obj_itr : m2m_object_list_) {
+        // Object names and object instances are unique as we use strict mode app definition parsing
+        
+        // Object names are unique
+        M2MObject* m2m_object = obj_itr;
+        if (object_name != m2m_object->name()) {
+            continue;
+        }
+
+        // Object instance is unique under a specific Object
+        M2MObjectInstance* m2m_object_instance = m2m_object->object_instance(object_instance_id);
+        if (nullptr == m2m_object_instance) {
+            continue;
+        }
+
+        // Found! Resource is unique under specific object
+        m2m_resource = m2m_object_instance->resource(resource_name.c_str());
+        break;
+    }
+    ret_pair.second = m2m_resource;
+
+    if (nullptr == ret_pair.second) {
+        TR_ERR("Resource %s not found", path.c_str());
+        ret_pair.first = Error::CCRBResourceNotFound;
+    }
+
+    return ret_pair;
 }
 
 } // namespace mbl

--- a/cloud-services/mbl-cloud-client/source/cloud-connect-resource-broker/ResourceBroker.h
+++ b/cloud-services/mbl-cloud-client/source/cloud-connect-resource-broker/ResourceBroker.h
@@ -228,9 +228,11 @@ protected:
         const std::vector<uint16_t> &resource_instance_ids,
         CloudConnectStatus &out_status);
 
+   
     /**
      * @brief Set resources values for multiple resources. 
-     *
+     * Calling this API is allowed right after register_resources() was called.
+     * 
      * @param access_token token used for access control to the resources pointed 
      *        from inout_set_operations vector. 
      * @param inout_set_operations vector of structures that provide all input and 
@@ -245,7 +247,7 @@ protected:
      *        - output_status is the status of the set operation for the corresponding 
      *          resource.
      *        Note: This parameter is valid, if MblError return error code 
-     *        was Error::None.  
+     *        is Error::None AND if out_status is CloudConnectStatus::STATUS_SUCCESS
      *
      * 
      * @param out_status cloud connect operation status for operations like 
@@ -253,7 +255,7 @@ protected:
      *        The set operation status is not returned via MblError, but by filling 
      *        corresponding value to the output_status in inout_set_operations.
      *        Note: This parameter is valid, if MblError return error code 
-     *        was Error::None.  
+     *        is Error::None.  
      * 
      * @return MblError returns Error::None if resource broker internal operations 
      *         were successfully finished, or error code otherwise.
@@ -262,6 +264,7 @@ protected:
         const std::string &access_token, 
         std::vector<ResourceSetOperation> &inout_set_operations,
         CloudConnectStatus &out_status);
+
 
     /**
      * @brief Get resources values from multiple resources. 
@@ -338,6 +341,88 @@ protected:
 
     typedef std::shared_ptr<RegistrationRecord> RegistrationRecord_ptr;
     typedef std::map<std::string, RegistrationRecord_ptr> RegistrationRecordMap;
+
+
+    /**
+     * @brief Validate resource data to be used in set/get operation against the registered resource
+     * 
+     * @param registration_record - Registration record
+     * @param resource_data - Resource data to be used in set / get operation
+     * 
+     * @return CloudConnectStatus - 
+     *      CloudConnectStatus::ERR_INVALID_RESOURCE_PATH - In case of invalid resource path
+     *      CloudConnectStatus::ERR_RESOURCE_NOT_FOUND - In case resource not found
+     *      CloudConnectStatus::ERR_INVALID_RESOURCE_TYPE - In case of invalid resource type
+     *      CloudConnectStatus::STATUS_SUCCESS - In case of valid resource data
+     */
+    CloudConnectStatus validate_resource_data(const RegistrationRecord_ptr registration_record,
+                                              ResourceData resource_data);
+
+    /**
+     * @brief Set value of one resource
+     * 
+     * @param registration_record - Registration record
+     * @param resource_data - Resource data to be used in set / get operation
+     * 
+     * @return CloudConnectStatus - 
+     *      CloudConnectStatus::ERR_INTERNAL_ERROR - In case set value in Mbed client failed
+     *      CloudConnectStatus::STATUS_SUCCESS - In case of valid resource data
+     */
+    CloudConnectStatus set_resource_value(const RegistrationRecord_ptr registration_record,
+                                          const ResourceData resource_data);
+
+    /**
+     * @brief Validate set operation param and update each resource output status.
+     * Used by set_resources_values() API.
+     * 
+     * @param registration_record - Registration record for set operation
+     * @param inout_set_operations vector of structures that provide all input and 
+     *        output parameters to perform setting operation. 
+     *        Each entry in inout_set_operations contains:
+     * 
+     *        input fields: 
+     *        - input_data is the data that includes resources's path type and value 
+     *          of the corresponding resource.
+     * 
+     *        output field: 
+     *        - output_status is the status of the set operation for the corresponding 
+     *          resource.
+     *        Note: This parameter is valid, if MblError return error code 
+     *        was Error::None.  
+     * 
+     * @return bool - true if inout_set_operations is valid, false if not.
+     */
+    bool validate_set_resources_input_params(
+        const RegistrationRecord_ptr registration_record,
+        std::vector<ResourceSetOperation>& inout_set_operations);
+
+    /**
+     * @brief Validate get operation param and update each resource output status.
+     * Used by get_resources_values() API.
+     * 
+     * @param registration_record - Registration record for set operation
+     * @param inout_get_operations vector of structures that provide all input and 
+     *        output parameters required to perform getting operation. 
+     *        Each entry in inout_get_operations contains:
+     * 
+     *        input fields: 
+     *        - inout_data.path field is the path of the corresponding resource 
+     *          who's value should be gotten. 
+     *        - inout_data.type field is the type of the resource data.
+     * 
+     *        output fields: 
+     *        - output_status is the status of the set operation for the corresponding
+     *          resource.
+     *        - inout_data.value field is the value that was gotten from resource. 
+     *          Use inout_data.value only if the output_status has SUCCESS value. 
+     *        Note: This parameter is valid, if MblError return error code 
+     *        was Error::None.  
+     * 
+     * @return bool - true if inout_get_operations is valid, false if not.
+     */
+    bool validate_get_resources_input_params(
+        RegistrationRecord_ptr registration_record,
+        std::vector<ResourceGetOperation>& inout_get_operations);
 
     /**
      * @brief Generate unique access token using sd_id128_randomize

--- a/cloud-services/mbl-cloud-client/source/cloud-connect-resource-broker/ResourceDefinitionParser.h
+++ b/cloud-services/mbl-cloud-client/source/cloud-connect-resource-broker/ResourceDefinitionParser.h
@@ -87,6 +87,7 @@ Notes:
 * "multiple_instance" and "observable" must have boolean value (e.g. true or false)
 * "mode" entry is mandatory and can either be "dynamic" or "static"
 * "observable" entry is mandatory in case of Dynamic resource, and it is not allowed to appear in case of Static resource
+* "value" entry is optional as resource value can be set later on
 
 */
 
@@ -110,9 +111,7 @@ public:
      *      Error::CCRBInvalidJson - I case of invalid resource definition  (e.g. Invalid structure or invalid M2M content such as missing mandatory entries)
      *      Error::CCRBCreateM2MObjFailed - If create of M2M object/object instance/resource failed
      */
-    static MblError build_object_list(
-        const std::string &application_resource_definition,
-        M2MObjectList &m2m_object_list);
+    static std::pair<MblError, M2MObjectList> build_object_list(const std::string& application_resource_definition);
 
 private:
 

--- a/cloud-services/mbl-cloud-client/tests/gtest/RegistrationRecordTester.cpp
+++ b/cloud-services/mbl-cloud-client/tests/gtest/RegistrationRecordTester.cpp
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2019 ARM Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "RegistrationRecordTester.h"
+#include "RegistrationRecord.h"
+#include "CloudConnectTrace.h"
+#include <gtest/gtest.h>
+
+#define TRACE_GROUP "ccrb-reg-record-tester"
+
+void RegistrationRecordTester::get_resource_identifiers_test(
+    const std::string& path,
+    mbl::MblError expected_error_status,
+    const std::string& expected_object_name,
+    uint16_t expected_object_instance_id,
+    const std::string& expected_resource_name,
+    const std::string& expected_resource_instance_name)
+{
+    std::string object_name, resource_name, resource_instance_name;
+    uint16_t object_instance_id = 0;
+    const mbl::MblError status = mbl::RegistrationRecord::get_resource_identifiers(
+        path,
+        object_name,
+        object_instance_id,
+        resource_name, resource_instance_name);
+    ASSERT_TRUE(expected_error_status == status);
+    if(mbl::MblError::None == status) {
+        ASSERT_TRUE(expected_object_name == object_name);
+        ASSERT_TRUE(expected_object_instance_id == object_instance_id);
+        ASSERT_TRUE(expected_resource_name == resource_name);
+        ASSERT_TRUE(expected_resource_instance_name == resource_instance_name);
+
+    }
+}

--- a/cloud-services/mbl-cloud-client/tests/gtest/RegistrationRecordTester.h
+++ b/cloud-services/mbl-cloud-client/tests/gtest/RegistrationRecordTester.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2019 ARM Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#ifndef RegistrationRecordTester_h_
+#define RegistrationRecordTester_h_
+
+#include "MblError.h"
+#include <string>
+
+/**
+ * @brief This class tests RegistrationRecord functionality
+ * 
+ * This class is a friend of RegistrationRecord class
+ * and is therefore able to evaluate private members and test operations
+ * 
+ */
+class RegistrationRecordTester {
+
+public:
+
+    /**
+     * @brief Get resource identifiers test
+     * 
+     * @param path - resource path 
+     * @param expected_error_status - Expected error status
+     * @param expected_object_name - Expected object name
+     * @param expected_object_instance_id - Expected object instance id
+     * @param expected_resource_name - Expected resource name
+     * @param expected_resource_instance_name - Expected resource instance name
+     */
+    void get_resource_identifiers_test(
+        const std::string& path,
+        mbl::MblError expected_error_status,
+        const std::string& expected_object_name,
+        uint16_t expected_object_instance_id,
+        const std::string& expected_resource_name,
+        const std::string& expected_resource_instance_name);
+};
+
+#endif // RegistrationRecordTester_h_

--- a/cloud-services/mbl-cloud-client/tests/gtest/RegistrationRecord_test.cpp
+++ b/cloud-services/mbl-cloud-client/tests/gtest/RegistrationRecord_test.cpp
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2019 ARM Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include "RegistrationRecordTester.h"
+#include "CloudConnectTrace.h"
+#include "TestInfra.h"
+
+#define TRACE_GROUP "ccrb-set_res_value-test"
+
+struct ResourceIdentifiersEntry{
+    const std::string resource_path;
+    mbl::MblError expected_error_status;
+    const std::string expected_object_name;
+    uint16_t expected_object_instance_id;
+    const std::string expected_resource_name;
+    const std::string expected_resource_instance_name;
+};
+
+const static std::vector<ResourceIdentifiersEntry> resource_identifiers_entry_vector = {
+    {
+        "/8888/11/111",
+        mbl::Error::None,
+        "8888",
+        11,
+        "111",
+        ""
+    },
+    {
+        "/8888/11/112",
+        mbl::Error::None,
+        "8888",
+        11,
+        "112",
+        ""
+    },
+    {
+        "/8888", // Path should be 3 level depth
+        mbl::MblError::CCRBInvalidResourcePath,
+        "",
+        0,
+        "",
+        ""
+    },
+    {
+        "/8888/11", // Path should be 3 level depth
+        mbl::MblError::CCRBInvalidResourcePath,
+        "",
+        0,
+        "",
+        ""
+    },
+    {
+        "/8888/11/111/1/2/3", // Path should be 3 level depth
+        mbl::MblError::CCRBInvalidResourcePath,
+        "",
+        0,
+        "",
+        ""
+    },
+    {
+        "/8888/11abc/111", // Object instance should be a number
+        mbl::MblError::CCRBInvalidResourcePath,
+        "",
+        0,
+        "",
+        ""        
+    },
+    {
+        "/8888/abc11/111", // Object instance should be a number
+        mbl::MblError::CCRBInvalidResourcePath,
+        "",
+        0,
+        "",
+        ""        
+    },
+    {
+        "//////8888/11/111", // Invalid prefix
+        mbl::MblError::CCRBInvalidResourcePath,
+        "",
+        0,
+        "",
+        ""        
+    },
+    {
+        "/8888//11/111", // Two subsequent "/"
+        mbl::MblError::CCRBInvalidResourcePath,
+        "",
+        0,
+        "",
+        ""        
+    },
+    {
+        "/8888/11/111/", // Path should not end with "/"
+        mbl::MblError::CCRBInvalidResourcePath,
+        "",
+        0,
+        "",
+        ""        
+    },    
+};
+
+class RegistrationRecordTest : public testing::TestWithParam<int>{};
+INSTANTIATE_TEST_CASE_P(RegistrationRecordParameterizedTest,
+                        RegistrationRecordTest,
+                        ::testing::Range(0, (int)resource_identifiers_entry_vector.size(), 1));
+
+/**
+ * @brief This parameterized test check get resource identifiers using valid / invalid paths
+ * 
+ */
+TEST_P(RegistrationRecordTest, get_resource_identifiers)
+{
+    GTEST_LOG_START_TEST;
+
+    const ResourceIdentifiersEntry &test_data = 
+        resource_identifiers_entry_vector[(size_t)GetParam()];
+
+    RegistrationRecordTester registration_record_tester;
+    registration_record_tester.get_resource_identifiers_test(
+        test_data.resource_path,
+        test_data.expected_error_status,
+        test_data.expected_object_name,
+        test_data.expected_object_instance_id,
+        test_data.expected_resource_name,
+        test_data.expected_resource_instance_name);
+}
+

--- a/cloud-services/mbl-cloud-client/tests/gtest/ResourceBrokerTester.h
+++ b/cloud-services/mbl-cloud-client/tests/gtest/ResourceBrokerTester.h
@@ -24,7 +24,7 @@
 /**
  * @brief This class tests ResourceBroker functionality
  * 
- * This class is a friend of ResourceBroker classe
+ * This class is a friend of ResourceBroker class
  * and is therefore able to evaluate private members and test operations
  * 
  */
@@ -75,10 +75,60 @@ public:
      *        application in all APIs that access (in any way) to the provided 
      *        (via app_resource_definition_json) set of resources. 
      * @param dbus_adapter_expected_status - expected dbus adapter cloud connect status
+     * 
+     * Note: register_resources_test() must be called before calling this API.
      */
     void mbed_client_register_update_callback_test(
         const std::string& access_token,
         CloudConnectStatus dbus_adapter_expected_status);
+
+    /**
+     * @brief Get resource by path and compare to expected status
+     * 
+     * @param access_token is a token that should be used by the client 
+     *        application in all APIs that access (in any way) to the provided 
+     *        (via app_resource_definition_json) set of resources. 
+     * @param path - resource path
+     * @param expected_error_status - expected error status
+     * 
+     * Note: register_resources_test() must be called before calling this API.
+     */
+    void get_m2m_resource_test(
+        const std::string& access_token,
+        const std::string& path,
+        mbl::MblError expected_error_status);
+
+    /**
+     * @brief Test set_resources_values API
+     * 
+     * @param access_token is a token that should be used by the client 
+     *        application in all APIs that access (in any way) to the provided 
+     *        (via app_resource_definition_json) set of resources. 
+     * @param inout_set_operations vector of structures that provide all input and 
+     *        output parameters to perform setting operation. 
+     *        Each entry in inout_set_operations contains:
+     * 
+     *        input fields: 
+     *        - input_data is the data that includes resources's path type and value 
+     *          of the corresponding resource.
+     * 
+     *        output field: 
+     *        - output_status is the status of the set operation for the corresponding 
+     *          resource.
+     *        Note: This parameter is valid, if MblError return error code 
+     *        was Error::None.  
+     * @param expected_inout_set_operations - expected inout_set operation
+     * @param expected_out_status cloud connect operation status for operations like 
+     *        access_token validity, access permissions to the resources, and so on. 
+     *        fills corresponding value to the output_status in inout_set_operations.
+     * 
+     * Note: register_resources_test() must be called before calling this API.
+     */
+    void set_resources_values_test(
+        const std::string& access_token,
+        std::vector<mbl::ResourceSetOperation>& inout_set_operations,
+        const std::vector<mbl::ResourceSetOperation> expected_inout_set_operations,
+        const CloudConnectStatus expected_out_status);
 
 private:
 

--- a/cloud-services/mbl-cloud-client/tests/gtest/ResourceBroker_register_test.cpp
+++ b/cloud-services/mbl-cloud-client/tests/gtest/ResourceBroker_register_test.cpp
@@ -18,12 +18,11 @@
 #include <gtest/gtest.h>
 #include "cloud-connect-resource-broker/ResourceBroker.h"
 #include "mbed-cloud-client/MbedCloudClient.h"
-
+#include "TestInfra.h"
 #include "ResourceBrokerTester.h"
 #include "ResourceDefinitionJson.h"
-#include "CloudConnectTrace.h"
 
-#define TRACE_GROUP "ccrb-resource-broker-test"
+#define TRACE_GROUP "ccrb-register-test"
 
 /**
  * @brief This test successful registration
@@ -35,11 +34,11 @@
  * 4. Resource Broker calls Mbed cloud client to register the resources
  * 5. Mbed cloud client calls ApplicationEndpoint's REGISTER callback upon SUCCESSFUL registration
  * 6. ApplicationEndpoint notify the Resource Broker that registration was SUCCESSFUL
- * 7. Resource Broker notifys DbusAdapter that registration was SUCCESSFUL
+ * 7. Resource Broker notifies DbusAdapter that registration was SUCCESSFUL
  */
 TEST(Resource_Broker_Positive, registration_success) {
 
-    TR_DEBUG("Enter");
+    GTEST_LOG_START_TEST;
 
     ResourceBrokerTester resource_broker_tester;
     const uintptr_t ipc_conn_handle = 0;
@@ -75,9 +74,9 @@ TEST(Resource_Broker_Positive, registration_success) {
  * 6. ApplicationEndpoint notify the Resource Broker that registration FAILED
  * 7. Resource Broker notifys DbusAdapter that registration was FAILED
  */
-TEST(Resource_Broker_Negative, parsing_succedded_registration_failed) {
+TEST(Resource_Broker_Negative, parsing_succeeded_registration_failed) {
 
-    TR_DEBUG("Enter");
+    GTEST_LOG_START_TEST;
 
     ResourceBrokerTester resource_broker_tester;
     const uintptr_t ipc_conn_handle = 0;
@@ -111,7 +110,7 @@ TEST(Resource_Broker_Negative, parsing_succedded_registration_failed) {
  */
 TEST(Resource_Broker_Negative, invalid_app_resource_definition_1) {
 
-    TR_DEBUG("Enter");
+    GTEST_LOG_START_TEST;
 
     ResourceBrokerTester resource_broker_tester;
     const uintptr_t ipc_conn_handle = 0;
@@ -132,20 +131,20 @@ TEST(Resource_Broker_Negative, invalid_app_resource_definition_1) {
 //NOTE: this test is valid only for Single app support
 TEST(Resource_Broker_Negative, already_registered) {
 
-    TR_DEBUG("Enter");
+    GTEST_LOG_START_TEST;
 
     ResourceBrokerTester resource_broker_tester;
     const uintptr_t ipc_conn_handle_1 = 1;
     const std::string application_resource_definition_1 =
         VALID_APP_RESOURCE_DEFINITION_OBJECT_WITH_SEVERAL_OBJECT_INSTANCES_AND_RESOURCES;
-    CloudConnectStatus cloud_connect_out_status_1;
+    CloudConnectStatus cloud_connect_out_status;
     std::string out_access_token_1;
 
     // Application 1 registering
     resource_broker_tester.register_resources_test(
         ipc_conn_handle_1,
         application_resource_definition_1,
-        cloud_connect_out_status_1,
+        cloud_connect_out_status,
         out_access_token_1,
         mbl::MblError::None, //expected error status
         CloudConnectStatus::STATUS_SUCCESS //expected cloud connect status
@@ -160,13 +159,12 @@ TEST(Resource_Broker_Negative, already_registered) {
     const uintptr_t ipc_conn_handle_2 = 2;
     const std::string application_resource_definition_2 =
         VALID_APP_RESOURCE_DEFINITION_TWO_OBJECTS_WITH_ONE_OBJECT_INSTANCE_AND_ONE_RESOURCE;
-    CloudConnectStatus cloud_connect_out_status_2;
     std::string out_access_token_2;
 
     resource_broker_tester.register_resources_test(
         ipc_conn_handle_2,
         application_resource_definition_2,
-        cloud_connect_out_status_2,
+        cloud_connect_out_status,
         out_access_token_2,
         mbl::MblError::None, //expected error status
         CloudConnectStatus::ERR_ALREADY_REGISTERED //expected cloud connect status
@@ -175,20 +173,20 @@ TEST(Resource_Broker_Negative, already_registered) {
 
 TEST(Resource_Broker_Negative, registration_in_progress) {
 
-    TR_DEBUG("Enter");
+    GTEST_LOG_START_TEST;
 
     ResourceBrokerTester resource_broker_tester;
     const uintptr_t ipc_conn_handle_1 = 1;
     const std::string application_resource_definition_1 =
         VALID_APP_RESOURCE_DEFINITION_OBJECT_WITH_SEVERAL_OBJECT_INSTANCES_AND_RESOURCES;
-    CloudConnectStatus cloud_connect_out_status_1;
+    CloudConnectStatus cloud_connect_out_status;
     std::string out_access_token_1;
 
     TR_DEBUG("Application 1 - Start registration");
     resource_broker_tester.register_resources_test(
         ipc_conn_handle_1,
         application_resource_definition_1,
-        cloud_connect_out_status_1,
+        cloud_connect_out_status,
         out_access_token_1,
         mbl::MblError::None, //expected error status
         CloudConnectStatus::STATUS_SUCCESS //expected cloud connect status
@@ -199,13 +197,12 @@ TEST(Resource_Broker_Negative, registration_in_progress) {
     const uintptr_t ipc_conn_handle_2 = 2;
     const std::string application_resource_definition_2 =
         VALID_APP_RESOURCE_DEFINITION_TWO_OBJECTS_WITH_ONE_OBJECT_INSTANCE_AND_ONE_RESOURCE;
-    CloudConnectStatus cloud_connect_out_status_2;
     std::string out_access_token_2;
 
     resource_broker_tester.register_resources_test(
         ipc_conn_handle_2,
         application_resource_definition_2,
-        cloud_connect_out_status_2,
+        cloud_connect_out_status,
         out_access_token_2,
         mbl::MblError::None, //expected error status
         CloudConnectStatus::ERR_REGISTRATION_ALREADY_IN_PROGRESS //expected cloud connect status
@@ -222,7 +219,7 @@ TEST(Resource_Broker_Negative, registration_in_progress) {
 // and succeeds in second try
 TEST(Resource_Broker_Negative, first_registration_fail_second_succeeded) {
 
-    TR_DEBUG("Enter");
+    GTEST_LOG_START_TEST;
 
     ResourceBrokerTester resource_broker_tester;
     const uintptr_t ipc_conn_handle = 0;
@@ -263,7 +260,7 @@ TEST(Resource_Broker_Negative, first_registration_fail_second_succeeded) {
 
 TEST(Resource_Broker_Positive, start_stop) {
 
-    TR_DEBUG("Enter");
+    GTEST_LOG_START_TEST;
 
     MbedCloudClient test_mbed_client;
     mbl::ResourceBroker resource_broker;

--- a/cloud-services/mbl-cloud-client/tests/gtest/ResourceBroker_set_resource_value_test.cpp
+++ b/cloud-services/mbl-cloud-client/tests/gtest/ResourceBroker_set_resource_value_test.cpp
@@ -1,0 +1,354 @@
+/*
+ * Copyright (c) 2019 ARM Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include "TestInfra.h"
+#include "ResourceBrokerTester.h"
+#include "ResourceDefinitionJson.h"
+
+#define TRACE_GROUP "ccrb-set_res_value-test"
+
+
+struct GetM2MResourceEntry{
+    const std::string application_resource_definition;
+    const std::string resource_path;
+    mbl::MblError expected_error_status;
+};
+
+const static std::vector<GetM2MResourceEntry> get_m2m_resource_entry_vector = {
+    {
+        VALID_APP_RESOURCE_DEFINITION_ONE_DYNAMIC_OBJECT_WITH_ONE_OBJECT_INSTANCE_AND_TWO_RESOURCE,
+        "/8888/11/111",
+        mbl::Error::None
+    },
+
+    {
+        VALID_APP_RESOURCE_DEFINITION_ONE_DYNAMIC_OBJECT_WITH_ONE_OBJECT_INSTANCE_AND_TWO_RESOURCE,
+        "/8888/11/112",
+        mbl::Error::None    
+    },
+    {
+        VALID_APP_RESOURCE_DEFINITION_ONE_DYNAMIC_OBJECT_WITH_ONE_OBJECT_INSTANCE_AND_TWO_RESOURCE,
+        "/8888", // Path should be 3 level depth
+        mbl::MblError::CCRBInvalidResourcePath        
+    },
+
+    {
+        VALID_APP_RESOURCE_DEFINITION_ONE_DYNAMIC_OBJECT_WITH_ONE_OBJECT_INSTANCE_AND_TWO_RESOURCE,
+        "/8888/11", // Path should be 3 level depth
+        mbl::MblError::CCRBInvalidResourcePath
+    },
+
+    {
+        VALID_APP_RESOURCE_DEFINITION_ONE_DYNAMIC_OBJECT_WITH_ONE_OBJECT_INSTANCE_AND_TWO_RESOURCE,
+        "/8888/11/111/1/2/3", // Path should be 3 level depth
+        mbl::MblError::CCRBInvalidResourcePath    
+    },
+
+    {
+        VALID_APP_RESOURCE_DEFINITION_ONE_DYNAMIC_OBJECT_WITH_ONE_OBJECT_INSTANCE_AND_TWO_RESOURCE,
+        "/8888/11abc/111", // Object instance should be a number
+        mbl::MblError::CCRBInvalidResourcePath    
+    },
+
+    {
+        VALID_APP_RESOURCE_DEFINITION_ONE_DYNAMIC_OBJECT_WITH_ONE_OBJECT_INSTANCE_AND_TWO_RESOURCE,
+        "/8888/11/333",
+        mbl::Error::CCRBResourceNotFound    
+    },
+
+    {
+        VALID_APP_RESOURCE_DEFINITION_ONE_DYNAMIC_OBJECT_WITH_ONE_OBJECT_INSTANCE_AND_TWO_RESOURCE,
+        "/8888/33/111",
+        mbl::Error::CCRBResourceNotFound   
+    },
+
+    {
+        VALID_APP_RESOURCE_DEFINITION_ONE_DYNAMIC_OBJECT_WITH_ONE_OBJECT_INSTANCE_AND_TWO_RESOURCE,
+        "/9999/11/111",
+        mbl::Error::CCRBResourceNotFound   
+    }
+};
+
+class ResourceBrokerTest : public testing::TestWithParam<int>{};
+INSTANTIATE_TEST_CASE_P(GetM2MResourceParameterizedTest,
+                        ResourceBrokerTest,
+                        ::testing::Range(0, (int)get_m2m_resource_entry_vector.size(), 1));
+
+/**
+ * @brief Test valid and invalid resource paths
+ * 
+ * The tested scenario is:
+ * 1. Resource Broker is called for register_resources() API
+ * 2. Application resource definition is parsed by ApplicationEndpoint class
+ * 3. Resource Broker registers ApplicationEndpoint's callbacks so Mbed client will call them
+ * 4. Resource Broker calls Mbed cloud client to register the resources
+ * 5. Get resource with valid path
+ */
+
+TEST_P(ResourceBrokerTest, get_m2m_resource)
+{
+    GTEST_LOG_START_TEST;
+
+    const GetM2MResourceEntry &test_data = 
+        get_m2m_resource_entry_vector[(size_t)GetParam()];
+
+    ResourceBrokerTester resource_broker_tester;
+    const uintptr_t ipc_conn_handle = 0;
+    CloudConnectStatus cloud_connect_out_status;
+    std::string out_access_token;
+
+    resource_broker_tester.register_resources_test(
+        ipc_conn_handle,
+        test_data.application_resource_definition,
+        cloud_connect_out_status,
+        out_access_token,
+        mbl::MblError::None, // expected error status
+        CloudConnectStatus::STATUS_SUCCESS // expected cloud connect status
+    );
+
+    // Check valid resource path
+    resource_broker_tester.get_m2m_resource_test(
+        out_access_token,
+        test_data.resource_path,
+        test_data.expected_error_status);
+}
+
+/**
+ * @brief Test setting value of string and integer
+ * 
+ */
+TEST(Resource_Broker_Positive, set_resource_value) {
+
+    GTEST_LOG_START_TEST;
+
+    ResourceBrokerTester resource_broker_tester;
+    const uintptr_t ipc_conn_handle = 0;
+    const std::string application_resource_definition = 
+        VALID_APP_RESOURCE_DEFINITION_ONE_DYNAMIC_OBJECT_WITH_ONE_OBJECT_INSTANCE_AND_TWO_RESOURCE;
+    CloudConnectStatus cloud_connect_out_status;
+    std::string out_access_token;
+
+    resource_broker_tester.register_resources_test(
+        ipc_conn_handle,
+        application_resource_definition,
+        cloud_connect_out_status,
+        out_access_token,
+        mbl::MblError::None, // expected error status
+        CloudConnectStatus::STATUS_SUCCESS // expected cloud connect status
+    );
+
+    // Above application resource definition register the following resources:
+    // 1. /8888/11/111 - dynamic string
+    // 2. /8888/11/112 - dynamic integer
+
+    std::vector<mbl::ResourceSetOperation> inout_set_operations;
+    mbl::ResourceData input_data_1("/8888/11/111", "string_value");
+    mbl::ResourceData input_data_2("/8888/11/112", 555);
+    mbl::ResourceSetOperation res_set_op_1(input_data_1);
+    mbl::ResourceSetOperation res_set_op_2(input_data_2);
+    inout_set_operations.push_back(res_set_op_1);
+    inout_set_operations.push_back(res_set_op_2);
+
+    std::vector<mbl::ResourceSetOperation> expected_inout_set_operations = inout_set_operations;
+
+    // Set expected statuses
+    expected_inout_set_operations[0].output_status_ = CloudConnectStatus::STATUS_SUCCESS;
+    expected_inout_set_operations[1].output_status_ = CloudConnectStatus::STATUS_SUCCESS;
+
+    resource_broker_tester.set_resources_values_test(
+        out_access_token,
+        inout_set_operations,
+        expected_inout_set_operations,
+        CloudConnectStatus::STATUS_SUCCESS // expected cloud connect status
+    );
+}
+
+/**
+ * @brief Test setting value of string to an integer resource and vica versa
+ * 
+ */
+TEST(Resource_Broker_Negative, set_resource_value_invalid_type) {
+
+    GTEST_LOG_START_TEST;
+
+    ResourceBrokerTester resource_broker_tester;
+    const uintptr_t ipc_conn_handle = 0;
+    const std::string application_resource_definition = 
+        VALID_APP_RESOURCE_DEFINITION_ONE_DYNAMIC_OBJECT_WITH_ONE_OBJECT_INSTANCE_AND_TWO_RESOURCE;
+    CloudConnectStatus cloud_connect_out_status;
+    std::string out_access_token;
+
+    resource_broker_tester.register_resources_test(
+        ipc_conn_handle,
+        application_resource_definition,
+        cloud_connect_out_status,
+        out_access_token,
+        mbl::MblError::None, // expected error status
+        CloudConnectStatus::STATUS_SUCCESS // expected cloud connect status
+    );
+
+    // Above application resource definition register the following resources:
+    // 1. /8888/11/111 - dynamic string
+    // 2. /8888/11/112 - dynamic integer
+
+    std::vector<mbl::ResourceSetOperation> inout_set_operations;
+    mbl::ResourceData input_data_1("/8888/11/111", 123); // should be a string
+    mbl::ResourceData input_data_2("/8888/11/112", "this_is_not_an_integer"); // should be integer
+    mbl::ResourceSetOperation res_set_op_1(input_data_1);
+    mbl::ResourceSetOperation res_set_op_2(input_data_2);
+    inout_set_operations.push_back(res_set_op_1);
+    inout_set_operations.push_back(res_set_op_2);
+
+    std::vector<mbl::ResourceSetOperation> expected_inout_set_operations = inout_set_operations;
+
+    // Set expected statuses
+    expected_inout_set_operations[0].output_status_ = CloudConnectStatus::ERR_INVALID_RESOURCE_TYPE;
+    expected_inout_set_operations[1].output_status_ = CloudConnectStatus::ERR_INVALID_RESOURCE_TYPE;
+
+    resource_broker_tester.set_resources_values_test(
+        out_access_token,
+        inout_set_operations,
+        expected_inout_set_operations,
+        CloudConnectStatus::STATUS_SUCCESS // expected cloud connect status
+    );
+}
+
+/**
+ * @brief Test setting value resource that wasn't registered
+ * 
+ */
+TEST(Resource_Broker_Negative, set_resource_value_resource_not_found) {
+
+    GTEST_LOG_START_TEST;
+
+    ResourceBrokerTester resource_broker_tester;
+    const uintptr_t ipc_conn_handle = 0;
+    const std::string application_resource_definition = 
+        VALID_APP_RESOURCE_DEFINITION_ONE_DYNAMIC_OBJECT_WITH_ONE_OBJECT_INSTANCE_AND_TWO_RESOURCE;
+    CloudConnectStatus cloud_connect_out_status;
+    std::string out_access_token;
+
+    resource_broker_tester.register_resources_test(
+        ipc_conn_handle,
+        application_resource_definition,
+        cloud_connect_out_status,
+        out_access_token,
+        mbl::MblError::None, // expected error status
+        CloudConnectStatus::STATUS_SUCCESS // expected cloud connect status
+    );
+
+    // Above application resource definition register the following resources:
+    // 1. /8888/11/111 - dynamic string
+    // 2. /8888/11/112 - dynamic integer
+
+    std::vector<mbl::ResourceSetOperation> inout_set_operations;
+    mbl::ResourceData input_data_1("/9999/11/111", "string_value"); //no such resource
+    mbl::ResourceData input_data_2("/8888/99/112", 555); //no such resource
+    mbl::ResourceSetOperation res_set_op_1(input_data_1);
+    mbl::ResourceSetOperation res_set_op_2(input_data_2);
+    inout_set_operations.push_back(res_set_op_1);
+    inout_set_operations.push_back(res_set_op_2);
+
+    std::vector<mbl::ResourceSetOperation> expected_inout_set_operations = inout_set_operations;
+
+    // Set expected statuses
+    expected_inout_set_operations[0].output_status_ = CloudConnectStatus::ERR_RESOURCE_NOT_FOUND;
+    expected_inout_set_operations[1].output_status_ = CloudConnectStatus::ERR_RESOURCE_NOT_FOUND;
+
+    resource_broker_tester.set_resources_values_test(
+        out_access_token,
+        inout_set_operations,
+        expected_inout_set_operations,
+        CloudConnectStatus::STATUS_SUCCESS // expected cloud connect status
+    );
+}
+
+/**
+ * @brief Test setting value resource with invalid path
+ * 
+ */
+TEST(Resource_Broker_Negative, set_resource_value_invalid_path) {
+
+    GTEST_LOG_START_TEST;
+
+    ResourceBrokerTester resource_broker_tester;
+    const uintptr_t ipc_conn_handle = 0;
+    const std::string application_resource_definition = 
+        VALID_APP_RESOURCE_DEFINITION_ONE_DYNAMIC_OBJECT_WITH_ONE_OBJECT_INSTANCE_AND_TWO_RESOURCE;
+    CloudConnectStatus cloud_connect_out_status;
+    std::string out_access_token;
+
+    resource_broker_tester.register_resources_test(
+        ipc_conn_handle,
+        application_resource_definition,
+        cloud_connect_out_status,
+        out_access_token,
+        mbl::MblError::None, // expected error status
+        CloudConnectStatus::STATUS_SUCCESS // expected cloud connect status
+    );
+
+    // Above application resource definition register the following resources:
+    // 1. /8888/11/111 - dynamic string
+    // 2. /8888/11/112 - dynamic integer
+
+    std::vector<mbl::ResourceSetOperation> inout_set_operations;
+    mbl::ResourceData input_data_1("8888/11/111", "string_value"); // path should start with "/"
+    mbl::ResourceData input_data_2("/8888/11", 555); // path not 3 level depth
+    mbl::ResourceSetOperation res_set_op_1(input_data_1);
+    mbl::ResourceSetOperation res_set_op_2(input_data_2);
+    inout_set_operations.push_back(res_set_op_1);
+    inout_set_operations.push_back(res_set_op_2);
+
+    std::vector<mbl::ResourceSetOperation> expected_inout_set_operations = inout_set_operations;
+
+    // Set expected statuses
+    expected_inout_set_operations[0].output_status_ = CloudConnectStatus::ERR_INVALID_RESOURCE_PATH;
+    expected_inout_set_operations[1].output_status_ = CloudConnectStatus::ERR_INVALID_RESOURCE_PATH;
+
+    resource_broker_tester.set_resources_values_test(
+        out_access_token,
+        inout_set_operations,
+        expected_inout_set_operations,
+        CloudConnectStatus::STATUS_SUCCESS // expected cloud connect status
+    );
+}
+
+/**
+ * @brief Test setting value resource with invalid access token
+ * 
+ */
+
+TEST(Resource_Broker_Negative, set_resource_invalid_access_token) {
+
+    GTEST_LOG_START_TEST;
+
+    std::vector<mbl::ResourceSetOperation> inout_set_operations;
+    mbl::ResourceData input_data_1("8888/11/111", "string_value"); // resource not registered
+    mbl::ResourceSetOperation res_set_op_1(input_data_1);
+    inout_set_operations.push_back(res_set_op_1);
+
+    std::string invalid_access_token("invalid_access_token");
+    std::vector<mbl::ResourceSetOperation> expected_inout_set_operations = inout_set_operations;
+    ResourceBrokerTester resource_broker_tester;
+    resource_broker_tester.set_resources_values_test(
+        invalid_access_token,
+        inout_set_operations,
+        expected_inout_set_operations,
+        CloudConnectStatus::ERR_INVALID_ACCESS_TOKEN // expected cloud connect status
+    );
+}

--- a/cloud-services/mbl-cloud-client/tests/gtest/ResourceDefinitionJson.h
+++ b/cloud-services/mbl-cloud-client/tests/gtest/ResourceDefinitionJson.h
@@ -126,14 +126,25 @@
           "delete"
         ],
         "observable": true,
-        "multiple_instance": true
+        "multiple_instance": false
+      },
+      "112": {
+        "mode": "dynamic",
+        "type": "integer",
+        "operations": [
+          "get",
+          "put",
+          "delete"
+        ],
+        "observable": true,
+        "multiple_instance": false
       }
     }
   }
 }
 */
-#define VALID_APP_RESOURCE_DEFINITION_ONE_DYMANIC_OBJECT_WITH_ONE_OBJECT_INSTANCE_AND_ONE_RESOURCE \
-  R"({"8888" : { "11" : { "111" : { "mode" : "dynamic", "type" : "string", "operations" : ["get","put", "delete"], "observable" : true, "multiple_instance" : true } } } })"
+#define VALID_APP_RESOURCE_DEFINITION_ONE_DYNAMIC_OBJECT_WITH_ONE_OBJECT_INSTANCE_AND_TWO_RESOURCE \
+  R"({"8888" : { "11" : { "111" : { "mode" : "dynamic", "type" : "string", "operations" : ["get","put", "delete"], "observable" : true, "multiple_instance" : false },  "112" : { "mode" : "dynamic", "type" : "integer", "operations" : ["get","put", "delete"], "observable" : true, "multiple_instance" : false } } } })"
 
 
 /*


### PR DESCRIPTION
implement set operations on registered resources.
Support only string and integer resources data types
Integrate set APIs with the Pelion Client
Add gtests, all pass on device.
Manually tested on Pelion.
Task: IOTMBL-1496

[==========] Running 40 tests from 10 test cases.
[----------] Global test environment set-up.
[----------] 3 tests from Resource_Broker_Positive
[ RUN      ] Resource_Broker_Positive.registration_success
[       OK ] Resource_Broker_Positive.registration_success (4 ms)
[ RUN      ] Resource_Broker_Positive.get_m2m_resource_valid_resource_path
[       OK ] Resource_Broker_Positive.get_m2m_resource_valid_resource_path (4 ms)
[ RUN      ] Resource_Broker_Positive.set_resource_value
[       OK ] Resource_Broker_Positive.set_resource_value (4 ms)
[----------] 3 tests from Resource_Broker_Positive (12 ms total)

[----------] 4 tests from AdapterParameterizedTest/ValidateRegisterResources
[ RUN      ] AdapterParameterizedTest/ValidateRegisterResources.BasicMethodReply/0
[       OK ] AdapterParameterizedTest/ValidateRegisterResources.BasicMethodReply/0 (10 ms)
[ RUN      ] AdapterParameterizedTest/ValidateRegisterResources.BasicMethodReply/3
[       OK ] AdapterParameterizedTest/ValidateRegisterResources.BasicMethodReply/3 (9 ms)
[ RUN      ] AdapterParameterizedTest/ValidateRegisterResources.BasicMethodReply/2
[       OK ] AdapterParameterizedTest/ValidateRegisterResources.BasicMethodReply/2 (8 ms)
[ RUN      ] AdapterParameterizedTest/ValidateRegisterResources.BasicMethodReply/1
[       OK ] AdapterParameterizedTest/ValidateRegisterResources.BasicMethodReply/1 (8 ms)
[----------] 4 tests from AdapterParameterizedTest/ValidateRegisterResources (35 ms total)

[----------] 1 test from EventManagerTestFixture
[ RUN      ] EventManagerTestFixture.basic_no_adapter
[       OK ] EventManagerTestFixture.basic_no_adapter (6 ms)
[----------] 1 test from EventManagerTestFixture (6 ms total)

[----------] 8 tests from JsonTest_Negative
[ RUN      ] JsonTest_Negative.Invalid_app_resource_definition_missing_Observable
[       OK ] JsonTest_Negative.Invalid_app_resource_definition_missing_Observable (1 ms)
[ RUN      ] JsonTest_Negative.Two_same_object_instances
[       OK ] JsonTest_Negative.Two_same_object_instances (0 ms)
[ RUN      ] JsonTest_Negative.Unsupported_resource_type
[       OK ] JsonTest_Negative.Unsupported_resource_type (1 ms)
[ RUN      ] JsonTest_Negative.Two_same_objects
[       OK ] JsonTest_Negative.Two_same_objects (0 ms)
[ RUN      ] JsonTest_Negative.Two_same_resource_names
[       OK ] JsonTest_Negative.Two_same_resource_names (1 ms)
[ RUN      ] JsonTest_Negative.Invalid_app_resource_definition_not_3_Level
[       OK ] JsonTest_Negative.Invalid_app_resource_definition_not_3_Level (0 ms)
[ RUN      ] JsonTest_Negative.Illegal_resource_operation
[       OK ] JsonTest_Negative.Illegal_resource_operation (1 ms)
[ RUN      ] JsonTest_Negative.Illegal_resource_mode
[       OK ] JsonTest_Negative.Illegal_resource_mode (1 ms)
[----------] 8 tests from JsonTest_Negative (7 ms total)

[----------] 1 test from DBusAdapterWithSelfEventTestFixture
[ RUN      ] DBusAdapterWithSelfEventTestFixture.adapter_self_event_callback
[       OK ] DBusAdapterWithSelfEventTestFixture.adapter_self_event_callback (36 ms)
[----------] 1 test from DBusAdapterWithSelfEventTestFixture (36 ms total)

[----------] 4 tests from AdapterParameterizedTest/ValidateDeregisterResources
[ RUN      ] AdapterParameterizedTest/ValidateDeregisterResources.BasicMethodReply/2
[       OK ] AdapterParameterizedTest/ValidateDeregisterResources.BasicMethodReply/2 (9 ms)
[ RUN      ] AdapterParameterizedTest/ValidateDeregisterResources.BasicMethodReply/3
[       OK ] AdapterParameterizedTest/ValidateDeregisterResources.BasicMethodReply/3 (8 ms)
[ RUN      ] AdapterParameterizedTest/ValidateDeregisterResources.BasicMethodReply/1
[       OK ] AdapterParameterizedTest/ValidateDeregisterResources.BasicMethodReply/1 (9 ms)
[ RUN      ] AdapterParameterizedTest/ValidateDeregisterResources.BasicMethodReply/0
[       OK ] AdapterParameterizedTest/ValidateDeregisterResources.BasicMethodReply/0 (8 ms)
[----------] 4 tests from AdapterParameterizedTest/ValidateDeregisterResources (34 ms total)

[----------] 10 tests from Resource_Broker_Negative
[ RUN      ] Resource_Broker_Negative.invalid_app_resource_definition_1
[       OK ] Resource_Broker_Negative.invalid_app_resource_definition_1 (1 ms)
[ RUN      ] Resource_Broker_Negative.first_registration_fail_second_succeeded
[       OK ] Resource_Broker_Negative.first_registration_fail_second_succeeded (6 ms)
[ RUN      ] Resource_Broker_Negative.registration_in_progress
[       OK ] Resource_Broker_Negative.registration_in_progress (5 ms)
[ RUN      ] Resource_Broker_Negative.set_resource_value_resource_not_found
[       OK ] Resource_Broker_Negative.set_resource_value_resource_not_found (3 ms)
[ RUN      ] Resource_Broker_Negative.get_m2m_resource_invalid_resource_path
[       OK ] Resource_Broker_Negative.get_m2m_resource_invalid_resource_path (5 ms)
[ RUN      ] Resource_Broker_Negative.set_resource_invalid_access_token
[       OK ] Resource_Broker_Negative.set_resource_invalid_access_token (1 ms)
[ RUN      ] Resource_Broker_Negative.set_resource_value_invalid_type
[       OK ] Resource_Broker_Negative.set_resource_value_invalid_type (4 ms)
[ RUN      ] Resource_Broker_Negative.already_registered
[       OK ] Resource_Broker_Negative.already_registered (5 ms)
[ RUN      ] Resource_Broker_Negative.set_resource_value_invalid_path
[       OK ] Resource_Broker_Negative.set_resource_value_invalid_path (4 ms)
[ RUN      ] Resource_Broker_Negative.parsing_succeeded_registration_failed
[       OK ] Resource_Broker_Negative.parsing_succeeded_registration_failed (3 ms)
[----------] 10 tests from Resource_Broker_Negative (39 ms total)

[----------] 4 tests from DBusAdapeterTestFixture
[ RUN      ] DBusAdapeterTestFixture.init_deinit
[       OK ] DBusAdapeterTestFixture.init_deinit (39 ms)
[ RUN      ] DBusAdapeterTestFixture.run_stop_with_external_exit_msg
[       OK ] DBusAdapeterTestFixture.run_stop_with_external_exit_msg (57 ms)
[ RUN      ] DBusAdapeterTestFixture.run_stop_with_self_request
[       OK ] DBusAdapeterTestFixture.run_stop_with_self_request (43 ms)
[ RUN      ] DBusAdapeterTestFixture.validate_service_exist
[       OK ] DBusAdapeterTestFixture.validate_service_exist (6 ms)
[----------] 4 tests from DBusAdapeterTestFixture (145 ms total)

[----------] 2 tests from JsonTest_Positive
[ RUN      ] JsonTest_Positive.Objects_with_several_object_instances_and_resources
[       OK ] JsonTest_Positive.Objects_with_several_object_instances_and_resources (7 ms)
[ RUN      ] JsonTest_Positive.Two_objects_with_one_object_instances_and_one_resource
[       OK ] JsonTest_Positive.Two_objects_with_one_object_instances_and_one_resource (4 ms)
[----------] 2 tests from JsonTest_Positive (11 ms total)

[----------] 3 tests from MailBoxTestFixture
[ RUN      ] MailBoxTestFixture.send_rcv_msg_single_thread
[       OK ] MailBoxTestFixture.send_rcv_msg_single_thread (47 ms)
[ RUN      ] MailBoxTestFixture.send_rcv_raw_message_multi_thread
[       OK ] MailBoxTestFixture.send_rcv_raw_message_multi_thread (1230 ms)
[ RUN      ] MailBoxTestFixture.init_deinit
[       OK ] MailBoxTestFixture.init_deinit (56 ms)
[----------] 3 tests from MailBoxTestFixture (1334 ms total)

[----------] Global test environment tear-down
[==========] 40 tests from 10 test cases ran. (1659 ms total)
[  PASSED  ] 40 tests.
