### PR TITLE
mbl-app-manager: Ensure user app parent dir is obtained correctly

### DIFF
--- a/application-framework/mbl-app-lifecycle-manager/tests/target/test_mbl-app-lifecycle-manager.py
+++ b/application-framework/mbl-app-lifecycle-manager/tests/target/test_mbl-app-lifecycle-manager.py
@@ -42,7 +42,7 @@ class TestAppLifecycleManager:
 
         print("Installing test container package - done.\n")
         # Init app_id that will be used in all tests
-        cls.app_path = os.path.join(MBL_APPS_DIR, cls.app_name)
+        cls.app_path = os.path.join(MBL_APPS_DIR, cls.app_name, "0")
 
         print("Installing test container package...")
         assert (

--- a/firmware-management/mbl-app-manager/mbl/app_manager/manager.py
+++ b/firmware-management/mbl-app-manager/mbl/app_manager/manager.py
@@ -7,10 +7,13 @@
 import os
 import shutil
 import subprocess
+from pathlib import Path
+
+from mbl.app_lifecycle_manager.container import get_oci_bundle_paths
 
 from .parser import parse_app_info, AppInfoParserError
 from .utils import log
-from mbl.app_lifecycle_manager.container import get_oci_bundle_paths
+
 
 APPS_PATH = os.path.join(os.sep, "home", "app")
 
@@ -97,9 +100,9 @@ class AppManager(object):
             )
             raise AppUninstallError(msg)
         else:
+            app_parent_dir = str(Path(app_path).resolve().parent)
             shutil.rmtree(app_path)
-            app_parent_dir = os.path.dirname(app_path)
-            if not os.listdir(app_parent_dir):
+            if not os.listdir(app_parent_dir) and app_parent_dir != APPS_PATH:
                 shutil.rmtree(app_parent_dir)
             log.info(
                 "'{}' removal from '{}' successful".format(app_name, app_path)


### PR DESCRIPTION
For [IOTMBL-1773 mbl-app-manager does not remove app correctly if the
app_path has a trailing "/"](https://jira.arm.com/browse/IOTMBL-1773)

* Use Python pathlib's Path instead of os to obtain the app parent
  directory.
* Ensure system test for mbl-app-lifecycle-manager installs dummy app in
  a subsdirectory inside the dummy app parent dir.
* Ensure /home/app is not removed in case application user passes the
  parent dir as `app_path`.

```
root@mbed-linux-os-2802:/scratch/firmware# mbl-app-update-manager one-app-update-payload.tar
Starting mbl-app-update-manager
Unpacking 'one-app-update-payload.tar'
Found archive member 'user-sample-app-package_1.0_armv7vet2hf-neon.ipk' in 'one-app-update-payload.tar' archive
'user-sample-app-package_1.0_armv7vet2hf-neon.ipk' is a valid ipk
Update package 'one-app-update-payload.tar' successfully unpacked

================ Package Control data =================
Package: user-sample-app-package
Version: 1.0
Status: unknown ok not-installed
Section: base
Architecture: armv7vet2hf-neon
Maintainer: Mbed Linux OS team <mbed-linux-team@arm.com>
Description: This package includes user sample "Hello world" application.

============= End of Package Control data =============
Application name is 'user-sample-app-package'
Installing 'user-sample-app-package' from '/mnt/cache/opkg/src_ipk/user-sample-app-package_1.0_armv7vet2hf-neon.ipk' to '/home/app/user-sample-app-package/0'

================ Package Control data =================
Package: user-sample-app-package
Version: 1.0
Status: unknown ok not-installed
Section: base
Architecture: armv7vet2hf-neon
Maintainer: Mbed Linux OS team <mbed-linux-team@arm.com>
Description: This package includes user sample "Hello world" application.

============= End of Package Control data =============
Application name is 'user-sample-app-package'
Installing user-sample-app-package (1.0) on user-sample-app-package
Configuring user-sample-app-package.
'user-sample-app-package' from '/mnt/cache/opkg/src_ipk/user-sample-app-package_1.0_armv7vet2hf-neon.ipk' package successfully installed at '/home/app/user-sample-app-package/0'
Run installed app(s): ['user-sample-app-package']
Stop running instance of 'user-sample-app-package' if any exist before running the new version
Run 'user-sample-app-package' from '/home/app/user-sample-app-package/0'
Container 'user-sample-app-package' created from '/home/app/user-sample-app-package/0'
Container 'user-sample-app-package' started
root@mbed-linux-os-2802:/scratch/firmware# ls -la /home/app/
total 4
drwxr-xr-x    4 root     root          1024 Mar  6 07:54 .
drwxr-xr-x    5 root     root          1024 Mar  5 10:20 ..
drwxr-xr-x    3 root     root          1024 Mar  6 07:54 opkg
drwxr-xr-x    3 root     root          1024 Mar  6 07:54 user-sample-app-package
root@mbed-linux-os-2802:/scratch/firmware# mbl-app-manager remove user-sample-app-package /home/app/user-sample-app-package/0/
Starting mbl-app-manager
Removing user-sample-app-package (1.0) from user-sample-app-package...
'user-sample-app-package' removal from '/home/app/user-sample-app-package/0/' successful
root@mbed-linux-os-2802:/scratch/firmware# ls -la /home/app/
total 3
drwxr-xr-x    3 root     root          1024 Mar  6 07:55 .
drwxr-xr-x    5 root     root          1024 Mar  5 10:20 ..
drwxr-xr-x    3 root     root          1024 Mar  6 07:55 opkg
root@mbed-linux-os-2802:/scratch/firmware# 
```

Synchronize merge with: https://github.com/ARMmbed/meta-mbl/pull/407