### PR TITLE
Fix error handling in MBL apps

### DIFF
--- a/application-framework/mbl-app-lifecycle-manager/mbl/app_lifecycle_manager/container.py
+++ b/application-framework/mbl-app-lifecycle-manager/mbl/app_lifecycle_manager/container.py
@@ -153,9 +153,9 @@ def create(container_id, bundle_path):
                 stderr=container_log,
             )
         except subprocess.CalledProcessError as error:
-            err_output = error.stdout.decode()
             msg = "Creating container '{}' failed, error: {}".format(
-                container_id, bundle_path, err_output
+                container_id,
+                error.stdout.decode() if error.stdout else error.returncode,
             )
             raise ContainerCreationError(msg)
 
@@ -182,9 +182,9 @@ def start(container_id):
             stderr=subprocess.STDOUT,
         )
     except subprocess.CalledProcessError as error:
-        err_output = error.stdout.decode()
         msg = "Starting container '{}' failed, error: '{}'".format(
-            container_id, err_output
+            container_id,
+            error.stdout.decode() if error.stdout else error.returncode,
         )
         raise ContainerStartError(msg)
     else:
@@ -209,9 +209,9 @@ def kill(container_id, signal="SIGTERM"):
             stderr=subprocess.STDOUT,
         )
     except subprocess.CalledProcessError as error:
-        err_output = error.stdout.decode()
         msg = "Killing container '{}' failed, error: '{}'".format(
-            container_id, err_output
+            container_id,
+            error.stdout.decode() if error.stdout else error.returncode,
         )
         raise ContainerKillError(msg)
     else:
@@ -238,9 +238,9 @@ def delete(container_id):
             stderr=subprocess.STDOUT,
         )
     except subprocess.CalledProcessError as error:
-        err_output = error.stdout.decode()
         msg = "Deleting container '{}' failed, error: '{}'".format(
-            container_id, err_output
+            container_id,
+            error.stdout.decode() if error.stdout else error.returncode,
         )
         raise ContainerDeleteError(msg)
     else:

--- a/firmware-management/mbl-app-manager/tests/native/test_case_generator_mbl-app-manager.py
+++ b/firmware-management/mbl-app-manager/tests/native/test_case_generator_mbl-app-manager.py
@@ -361,12 +361,14 @@ def _main():
             package_architecture="invalid-architecture",
             package_files=package_files,
             return_code_install=1,
-            # Expect successful removal even if installation failed.
+            # Expect unsuccessful removal.
             # This is because OPKG tries to install the package and puts some
-            # files where the application was to be installed.
-            # OPKG successfully removes the files upon request to remove the
-            # application.
-            return_code_remove=0,
+            # files where the application was to be installed, however,
+            # mbl-app-manager removes the partly installed application in case
+            # of installation failure.
+            # OPKG does not successfully removes the application because of the
+            # cleanup by mbl-app-manager
+            return_code_remove=1,
         )
         app_manager_test_case_generator.create_test_files(test_case_config4)
 


### PR DESCRIPTION
[For IOTMBL-1777 Write the steps for manually testing
`mbl-app-update-manager`](https://jira.arm.com/browse/IOTMBL-1777)

* Remove partly installed app in case of failure to install.
* Replace command to run subprocess in order to get stdout
* Print stdout from subprocess only if available otherwise print error
  code

Test: Manually tested that applications are rolled back in case of failure to install or run the OCI bundle