### PR TITLE
Fix mbl-app-lifecycle-manager system test

### DIFF
--- a/application-framework/mbl-app-lifecycle-manager/tests/target/test_mbl-app-lifecycle-manager.py
+++ b/application-framework/mbl-app-lifecycle-manager/tests/target/test_mbl-app-lifecycle-manager.py
@@ -70,7 +70,7 @@ class TestAppLifecycleManager:
         # Do not assert because mbl-app-lifecycle-manager returns an error code
         # if instructed to kill a non-existing application.
         print("Teardown method start...")
-        kill_app(cls.app_name, False) == alm_cli.ReturnCode.SUCCESS.value
+        kill_app(cls.app_name, False)
         print("Teardown method end")
 
     # ---------------------------- Test Methods -----------------------------


### PR DESCRIPTION
[For IOTMBL-1791 Fix failing mbl-app-lifecycle-manager system tests](https://jira.arm.com/browse/IOTMBL-1791)

Do not assert app termination in teardown as mbl-app-lifecycle-manager
now returns an error code if instructed to terminate/kill a nonexistent
user application. If the test case successfully managed to terminate/kill
the test user application, killing it in the teardown method will not
result in a successful return code.