### PR TITLE
Fix rootfs update test

### DIFF
--- a/ci/lava/tests/mbl-cli-run-rootfs-test.sh
+++ b/ci/lava/tests/mbl-cli-run-rootfs-test.sh
@@ -84,7 +84,9 @@ else
 
         if [ $retVal -eq 0 ]; then
             printf "<LAVA_SIGNAL_TESTCASE TEST_CASE_ID=rootfs_download RESULT=pass>\n"
-            # Tar it up in the expected manner
+            # Tar it up in the expected manner. Take the url of the tar file
+            # specified in rootfs_image and remove everything upto and
+            # including the final "/"
             tar -cf payload.tar "${rootfs_image##*/}" '--transform=s/.*/rootfs.tar.xz/'
 
             # Now copy the tar file to the DUT


### PR DESCRIPTION
Change the image name that is in the payload to be dependents on the
rootfs image selected (instead of Warp7 specific).