### PR TITLE
Correct test names in LAVA output.

### DIFF
--- a/ci/lava/dependencies/send_junit_results_to_lava.py
+++ b/ci/lava/dependencies/send_junit_results_to_lava.py
@@ -47,7 +47,12 @@ def CreateLavaOutputText(testcase):
         result = "pass"
 
     return "{}{}::{} {}{}{}".format(
-        lava_signal, name, testcase.name, result_str, result, terminator
+        lava_signal,
+        name,
+        testcase.name.replace(" ", "_"),
+        result_str,
+        result,
+        terminator,
     )
 
 


### PR DESCRIPTION
Changed and space in test names to underscores as spaces beak the LAVA
signal handling.