### PR TITLE
Modify user-sample-app-package app and system test IPKs to install an…

### DIFF
--- a/application-framework/mbl-app-lifecycle-manager/tests/target/test_mbl-app-lifecycle-manager.py
+++ b/application-framework/mbl-app-lifecycle-manager/tests/target/test_mbl-app-lifecycle-manager.py
@@ -19,9 +19,7 @@ MBL_APPS_DIR = os.path.join(os.sep, "home", "app")
 MBL_APP_MANAGER = "mbl-app-manager"
 MBL_APP_LIFECYCLE_MANAGER = "mbl-app-lifecycle-manager"
 APP_PKG = os.path.join(
-    os.sep,
-    "scratch",
-    "app-lifecycle-manager-test-package_1.0_armv7vet2hf-neon.ipk",
+    os.sep, "scratch", "app-lifecycle-manager-test-package_1.0_any.ipk"
 )
 
 

--- a/firmware-management/mbl-app-manager/tests/native/test_case_generator_mbl-app-manager.py
+++ b/firmware-management/mbl-app-manager/tests/native/test_case_generator_mbl-app-manager.py
@@ -308,7 +308,7 @@ def _main():
             package_description="This is a valid ipk1 description.\n"
             "Expecting to successfully installed.",
             package_version="1.0",
-            package_architecture="armv7vet2hf-neon",
+            package_architecture="any",
             package_files=package_files,
             return_code_install=0,
             return_code_remove=0,
@@ -326,7 +326,7 @@ def _main():
             package_description="This is a valid ipk2 description.\n"
             "Expecting to successfully installed.",
             package_version="2.0",
-            package_architecture="armv7vet2hf-neon",
+            package_architecture="any",
             package_files=package_files,
             return_code_install=0,
             return_code_remove=0,
@@ -340,7 +340,7 @@ def _main():
             package_name="invalid-ipk1",
             package_description="Invalid ipk1 file (missing package name).",
             package_version="2.0",
-            package_architecture="armv7vet2hf-neon",
+            package_architecture="any",
             package_files=package_files,
             return_code_install=1,
             # Expect removal failure because no attempt to install the app

--- a/tutorials/helloworld/src_bundle/config.json
+++ b/tutorials/helloworld/src_bundle/config.json
@@ -98,16 +98,6 @@
 			]
 		},
 		{
-			"destination": "/dev/mqueue",
-			"type": "mqueue",
-			"source": "mqueue",
-			"options": [
-				"nosuid",
-				"noexec",
-				"nodev"
-			]
-		},
-		{
 			"destination": "/sys",
 			"type": "sysfs",
 			"source": "sysfs",

--- a/tutorials/helloworld/src_opkg/CONTROL/control
+++ b/tutorials/helloworld/src_opkg/CONTROL/control
@@ -1,8 +1,7 @@
 Package: user-sample-app-package
 Version: 1.0
-Architecture: armv7vet2hf-neon
+Architecture: any
 Maintainer: Mbed Linux OS team <mbed-linux-team@arm.com>
 Section: base
 Priority: optional
 Description: This package includes user sample "Hello world" application.
-


### PR DESCRIPTION
For IOMTBL-1796 IMX8 system test failure due to incompatible
architecture field on test ipks

The sample application and generated IPKs could not be installed 
on NXP 8M Mini EVK because its architecture type is different from
that of other supported MBL boards. The IPKs need to be modified
to indicate that  they can be installed on any platform. This is required
by OPKG which keeps a list of installable package architectures.

This also removes the mqueue device specification from the OCI runtime
bundle configiguration file as it is not included on NXP 8M Mini EVK.