### PR TITLE
Update user-sample-app-package IPK references in LAVA scripts (#139)

### DIFF
--- a/ci/lava/tests/lxc-build-helloworld.sh
+++ b/ci/lava/tests/lxc-build-helloworld.sh
@@ -24,8 +24,8 @@ chmod +x ./build-armv7
 
 # Get the image and put it into a tar file
 cd release/ipk/ || exit
-tar -cvf user-sample-app-package_1.0_armv7vet2hf-neon.ipk.tar user-sample-app-package_1.0_armv7vet2hf-neon.ipk
+tar -cvf user-sample-app-package_1.0_any.ipk.tar user-sample-app-package_1.0_any.ipk
 
 # Copy the tar file to the home directory. This makes ii available for subsequent test steps.
-cp user-sample-app-package_1.0_armv7vet2hf-neon.ipk.tar /home/ubuntu/user-sample-app-package_1.0_armv7vet2hf-neon.ipk.tar
+cp user-sample-app-package_1.0_any.ipk.tar /home/ubuntu/user-sample-app-package_1.0_any.ipk.tar
 

--- a/ci/lava/tests/mbl-cli-run-helloworld.sh
+++ b/ci/lava/tests/mbl-cli-run-helloworld.sh
@@ -32,11 +32,11 @@ else
     $mbl_command shell "rm /var/log/app/user-sample-app-package.log"
 
     # Now copy the package and python checker script to the DUT
-    $mbl_command put /home/ubuntu/user-sample-app-package_1.0_armv7vet2hf-neon.ipk.tar /home/root
+    $mbl_command put /home/ubuntu/user-sample-app-package_1.0_any.ipk.tar /home/root
     $mbl_command put ./ci/lava/dependencies/check_container.py /home/root
 
     # Now install the package - this should cause it to run
-    $mbl_command shell "mbl-app-update-manager /home/root/user-sample-app-package_1.0_armv7vet2hf-neon.ipk.tar"
+    $mbl_command shell "mbl-app-update-manager /home/root/user-sample-app-package_1.0_any.ipk.tar"
 
     # Check it is executing as expected
     $mbl_command shell "python3 /home/root/check_container.py user-sample-app-package"
@@ -61,7 +61,7 @@ else
 
     # Attempt to cleanup after the run
     $mbl_command shell "mbl-app-manager remove user-sample-app-package /home/app/user-sample-app-package"
-    $mbl_command shell "rm /home/root/user-sample-app-package_1.0_armv7vet2hf-neon.ipk.tar"
+    $mbl_command shell "rm /home/root/user-sample-app-package_1.0_any.ipk.tar"
     $mbl_command shell "rm /var/log/app/user-sample-app-package.log"
 
 fi


### PR DESCRIPTION
The IPK filename changed from user-sample-app-package_1.0_armv7vet2hf-neon.ipk
to user-sample-app-package_1.0_any.ipk due to the change of architecture type
in the IPK control data.