### PR TITLE
Enforce single active connection (client), change interface/object/service names, disable DeregisterResourcesStatus and more

### DIFF
--- a/cloud-services/mbl-cloud-client/source/cloud-connect-resource-broker/CloudConnectExternalTypes.h
+++ b/cloud-services/mbl-cloud-client/source/cloud-connect-resource-broker/CloudConnectExternalTypes.h
@@ -37,6 +37,7 @@ enum CloudConnectStatus {
     ERR_RESOURCE_NOT_FOUND                          = 0x1006,
     ERR_INVALID_RESOURCE_TYPE                       = 0x1007,
     ERR_NOT_SUPPORTED                               = 0x1008,
+	ERR_NUM_ALLOWED_CONNECTIONS_EXCEEDED            = 0x1009
 };
  
 typedef enum CloudConnectStatus CloudConnectStatus;
@@ -49,17 +50,28 @@ static inline bool is_CloudConnectStatus_error(const CloudConnectStatus val){
     return val >= ERR_FIRST;
 }
 
-// mbed.Cloud.Connect DBus errors definitions
-#define CLOUD_CONNECT_ERR_INTERNAL_ERROR "mbed.Cloud.Connect.Error.InternalError"
-#define CLOUD_CONNECT_ERR_INVALID_APPLICATION_RESOURCES_DEFINITION "mbed.Cloud.Connect.Error.InvalidApplicationResourceDefinition"
-#define CLOUD_CONNECT_ERR_REGISTRATION_ALREADY_IN_PROGRESS "mbed.Cloud.Connect.Error.RegistrationAlreadyInProgress"
-#define CLOUD_CONNECT_ERR_ALREADY_REGISTERED "mbed.Cloud.Connect.Error.AlreadyRegistered"
-#define CLOUD_CONNECT_ERR_INVALID_ACCESS_TOKEN "mbed.Cloud.Connect.Error.InvalidAccessToken"
-#define CLOUD_CONNECT_ERR_INVALID_RESOURCE_PATH "mbed.Cloud.Connect.Error.InvalidResourcePath"
-#define CLOUD_CONNECT_ERR_RESOURCE_NOT_FOUND "mbed.Cloud.Connect.Error.ResourceNotFound"
-#define CLOUD_CONNECT_ERR_INVALID_RESOURCE_TYPE "mbed.Cloud.Connect.Error.InvalidResourceType"
-#define CLOUD_CONNECT_ERR_NOT_SUPPORTED "mbed.Cloud.Connect.Error.NotSupported"
-
+// com.mbed.Pelion1.Connect.Error definitions
+#define CLOUD_CONNECT_ERR_INTERNAL_ERROR \
+    "com.mbed.Pelion1.Connect.Error.InternalError"
+#define CLOUD_CONNECT_ERR_INVALID_APPLICATION_RESOURCES_DEFINITION \
+    "com.mbed.Pelion1.Connect.Error.InvalidApplicationResourceDefinition"
+#define CLOUD_CONNECT_ERR_REGISTRATION_ALREADY_IN_PROGRESS \
+    "com.mbed.Pelion1.Connect.Error.RegistrationAlreadyInProgress"
+#define CLOUD_CONNECT_ERR_ALREADY_REGISTERED \
+    "com.mbed.Pelion1.Connect.Error.AlreadyRegistered"
+#define CLOUD_CONNECT_ERR_INVALID_RESOURCE_PATH \
+	"com.mbed.Pelion1.Connect.Error.InvalidResourcePath"
+#define CLOUD_CONNECT_ERR_RESOURCE_NOT_FOUND \
+	"com.mbed.Pelion1.Connect.Error.ResourceNotFound"
+#define CLOUD_CONNECT_ERR_INVALID_RESOURCE_TYPE \
+	"com.mbed.Pelion1.Connect.Error.InvalidResourceType"
+#define CLOUD_CONNECT_ERR_INVALID_ACCESS_TOKEN \
+	"com.mbed.Pelion1.Connect.Error.InvalidAccessToken"
+#define CLOUD_CONNECT_ERR_NOT_SUPPORTED \
+	"mbed.Cloud.Connect.Error.NotSupported"
+#define CLOUD_CONNECT_ERR_NUM_ALLOWED_CONNECTIONS_EXCEEDED \
+    "com.mbed.Pelion1.Connect.Error.NumAllowedConnectionsExceeded"
+    
 /** 
  * @brief Returns corresponding D-Bus format error. 
  * The error returned is a string in a D-Bus format that corresponds to provided enum. 

--- a/cloud-services/mbl-cloud-client/source/cloud-connect-resource-broker/CloudConnectTypes.cpp
+++ b/cloud-services/mbl-cloud-client/source/cloud-connect-resource-broker/CloudConnectTypes.cpp
@@ -81,6 +81,11 @@ const char* CloudConnectStatus_to_str(const CloudConnectStatus status)
         SWITCH_RETURN_STRINGIFIED_VALUE(ERR_INVALID_APPLICATION_RESOURCES_DEFINITION);
         SWITCH_RETURN_STRINGIFIED_VALUE(ERR_REGISTRATION_ALREADY_IN_PROGRESS);
         SWITCH_RETURN_STRINGIFIED_VALUE(ERR_ALREADY_REGISTERED);
+        SWITCH_RETURN_STRINGIFIED_VALUE(ERR_NUM_ALLOWED_CONNECTIONS_EXCEEDED);
+        SWITCH_RETURN_STRINGIFIED_VALUE(ERR_INVALID_RESOURCE_PATH);
+        SWITCH_RETURN_STRINGIFIED_VALUE(ERR_RESOURCE_NOT_FOUND);
+        SWITCH_RETURN_STRINGIFIED_VALUE(ERR_INVALID_RESOURCE_TYPE);
+        SWITCH_RETURN_STRINGIFIED_VALUE(ERR_INVALID_ACCESS_TOKEN);
 
     default: return "Unknown CloudConnectStatus value";
     }
@@ -90,18 +95,21 @@ const char* CloudConnectStatus_to_readable_str(const CloudConnectStatus status)
 {
     switch (status)
     {
-    case STATUS_SUCCESS: return "Status success";
-    case ERR_INTERNAL_ERROR: return "Internal error in Cloud Connect infrastructure";
+    case STATUS_SUCCESS: return "Status success.";
+    case ERR_INTERNAL_ERROR: return "Internal error in Cloud Connect infrastructure.";
     case ERR_INVALID_APPLICATION_RESOURCES_DEFINITION:
-        return "Invalid application resource definition";
-    case ERR_REGISTRATION_ALREADY_IN_PROGRESS: return "Registration already in progress";
-    case ERR_ALREADY_REGISTERED: return "Already registered";
-    case ERR_INVALID_ACCESS_TOKEN: return "Invalid access token";
-    case ERR_INVALID_RESOURCE_PATH: return "Invalid resource path";
-    case ERR_RESOURCE_NOT_FOUND: return "Resource not found";
-    case ERR_INVALID_RESOURCE_TYPE: return "Invalid resource type";
+        return "Invalid application resource definition.";
+    case ERR_REGISTRATION_ALREADY_IN_PROGRESS: return "Registration already in progress.";
+    case ERR_ALREADY_REGISTERED: return "Already registered.";
+    case ERR_INVALID_ACCESS_TOKEN: return "Invalid access token.";
+    case ERR_INVALID_RESOURCE_PATH: return "Invalid resource path.";
+    case ERR_RESOURCE_NOT_FOUND: return "Resource not found.";
+    case ERR_INVALID_RESOURCE_TYPE: return "Invalid resource type.";
+    case ERR_NOT_SUPPORTED: return "Not supported.";
+    case ERR_NUM_ALLOWED_CONNECTIONS_EXCEEDED:
+        return "No more connetions allowed to work simultaneously.";
 
-    default: return "Unknown Cloud Connect Status or Error";
+    default: return "Unknown Cloud Connect Status or Error.";
     }
 }
 
@@ -117,6 +125,8 @@ const char* CloudConnectStatus_error_to_DBus_format_str(const CloudConnectStatus
         RETURN_DBUS_FORMAT_ERROR(ERR_INVALID_RESOURCE_PATH);
         RETURN_DBUS_FORMAT_ERROR(ERR_RESOURCE_NOT_FOUND);
         RETURN_DBUS_FORMAT_ERROR(ERR_INVALID_RESOURCE_TYPE);
+        RETURN_DBUS_FORMAT_ERROR(ERR_NOT_SUPPORTED);
+        RETURN_DBUS_FORMAT_ERROR(ERR_NUM_ALLOWED_CONNECTIONS_EXCEEDED);
 
     default: return "Unknown CloudConnectStatus value";
     }

--- a/cloud-services/mbl-cloud-client/source/cloud-connect-resource-broker/DBusAdapter_Impl.h
+++ b/cloud-services/mbl-cloud-client/source/cloud-connect-resource-broker/DBusAdapter_Impl.h
@@ -19,11 +19,12 @@
 #include <set>
 #include <string>
 
-// sd-bus vtable object, implements the com.mbed.Cloud.Connect1 interface
+
+// sd-bus vtable object, implements the com.mbed.Pelion1.Connect interface
 // Keep those definitions here for testing
-#define DBUS_CLOUD_SERVICE_NAME                         "com.mbed.Cloud"
-#define DBUS_CLOUD_CONNECT_INTERFACE_NAME               "com.mbed.Cloud.Connect1"
-#define DBUS_CLOUD_CONNECT_OBJECT_PATH                  "/com/mbed/Cloud/Connect1"
+#define DBUS_CLOUD_SERVICE_NAME                         "com.mbed.Pelion1"
+#define DBUS_CLOUD_CONNECT_INTERFACE_NAME               "com.mbed.Pelion1.Connect"
+#define DBUS_CLOUD_CONNECT_OBJECT_PATH                  "/com/mbed/Pelion1/Connect"
 
 #define DBUS_CC_REGISTER_RESOURCES_METHOD_NAME          "RegisterResources"
 #define DBUS_CC_DEREGISTER_RESOURCES_METHOD_NAME        "DeregisterResources"
@@ -358,6 +359,19 @@ private:
      * called sd_bus functions in case of failure
      */
     int bus_track_sender(const char * bus_name);
+
+    /**
+     * @brief receives the current sender unique connection ID. 
+     * Decide if adapter should continue to process the arrived message. If false is returned, 
+     * reply with relevant CloudConnectStatus .See returned values for more info.
+     * 
+     * @param source - a valid unique connection ID of the sender
+     * @return true -  If this connection unique ID is already tracked or there is no tracked ID - 
+     * continue in calling function
+     * @return false  - if already exist a tracked connection which is not the input connection - 
+     * do not continue processing the message
+     */
+    bool bus_enforce_single_connection(std::string& source);
 
     // sd-bus bus connection handle
     sd_bus* connection_handle_ = nullptr;

--- a/cloud-services/mbl-cloud-client/source/cloud-connect-resource-broker/DBusService.c
+++ b/cloud-services/mbl-cloud-client/source/cloud-connect-resource-broker/DBusService.c
@@ -61,7 +61,7 @@ const sd_bus_vtable cloud_connect_service_vtable[] = {
     // CloudConnectError (Cloud Connect Error)
     // TBD
 
-    // com.mbed.Cloud.Connect1.RegisterResources
+    // com.mbed.Pelion1.Connect.RegisterResources
     //
     // As a Method :
     // UINT32, STRING RegisterResources(STRING json)
@@ -91,7 +91,7 @@ const sd_bus_vtable cloud_connect_service_vtable[] = {
     SD_BUS_METHOD(
         "RegisterResources", "s", "us", incoming_bus_message_callback, SD_BUS_VTABLE_UNPRIVILEGED),
 
-    // com.mbed.Cloud.Connect1.RegisterResourcesStatus
+    // com.mbed.Pelion1.Connect.RegisterResourcesStatus
     //
     // As a Signal :
     // RegisterResourcesStatus(UINT32 status)
@@ -108,7 +108,8 @@ const sd_bus_vtable cloud_connect_service_vtable[] = {
     // TBD
     SD_BUS_SIGNAL("RegisterResourcesStatus", "u", 0),
 
-    // com.mbed.Cloud.Connect1.DeregisterResources
+    // TODO: This method call is disabled for now - upper layer does not support it as expected.
+    // com.mbed.Pelion1.Connect.DeregisterResources
     //
     // As a Method :
     // UINT32 DeregisterResources(STRING access_token)
@@ -137,10 +138,13 @@ const sd_bus_vtable cloud_connect_service_vtable[] = {
     // 1            UINT32 Cloud Connect Error
     // ==Possible Cloud Connect Error values==
     // TBD
-    SD_BUS_METHOD(
-        "DeregisterResources", "s", "u", incoming_bus_message_callback, SD_BUS_VTABLE_UNPRIVILEGED),
+    // FIXME - This method should be uncommented after we deregistration is supported on higher
+    // layers.
+    // SD_BUS_METHOD(
+    //    "DeregisterResources", "s", "u", incoming_bus_message_callback,
+    //    SD_BUS_VTABLE_UNPRIVILEGED),
 
-    // com.mbed.Cloud.Connect1.DeregisterResourcesStatus
+    // com.mbed.Pelion1.Connect.DeregisterResourcesStatus
     //
     // As a Signal :
     // DeregisterResourcesStatus(UINT32 status)
@@ -155,9 +159,9 @@ const sd_bus_vtable cloud_connect_service_vtable[] = {
     //
     // ==Possible Cloud Connect Error values==
     // TBD
-    SD_BUS_SIGNAL("DeregisterResourcesStatus", "u", 0),
+    // SD_BUS_SIGNAL("DeregisterResourcesStatus", "u", 0),
 
-    // com.mbed.Cloud.Connect1.AddResourceInstances
+    // com.mbed.Pelion1.Connect.AddResourceInstances
     //
     // As a Method :
     // UINT32 AddResourceInstances(STRING access_token,
@@ -196,7 +200,7 @@ const sd_bus_vtable cloud_connect_service_vtable[] = {
                   incoming_bus_message_callback,
                   SD_BUS_VTABLE_UNPRIVILEGED),
 
-    // com.mbed.Cloud.Connect1.AddResourceInstancesStatus
+    // com.mbed.Pelion1.Connect.AddResourceInstancesStatus
     //
     // As a Signal :
     // AddResourceInstancesStatus(UINT32 status)
@@ -213,7 +217,7 @@ const sd_bus_vtable cloud_connect_service_vtable[] = {
     // TBD
     SD_BUS_SIGNAL("AddResourceInstancesStatus", "u", 0),
 
-    // com.mbed.Cloud.Connect1.RemoveResourceInstances
+    // com.mbed.Pelion1.Connect.RemoveResourceInstances
     //
     // As a Method :
     // UINT32 RemoveResourceInstances(STRING access_token,
@@ -253,7 +257,7 @@ const sd_bus_vtable cloud_connect_service_vtable[] = {
                   incoming_bus_message_callback,
                   SD_BUS_VTABLE_UNPRIVILEGED),
 
-    // com.mbed.Cloud.Connect1.RemoveResourceInstancesStatus
+    // com.mbed.Pelion1.Connect.RemoveResourceInstancesStatus
     //
     // As a Signal :
     // RemoveResourceInstancesStatus(UINT32 status)
@@ -270,7 +274,7 @@ const sd_bus_vtable cloud_connect_service_vtable[] = {
     // TBD
     SD_BUS_SIGNAL("RemoveResourceInstancesStatus", "u", 0),
 
-    // com.mbed.Cloud.Connect1.SetResourcesValues
+    // com.mbed.Pelion1.Connect.SetResourcesValues
     //
     // As a Method :
     // ARRAY_of_UINT32 SetResourcesValues(STRING access_token,
@@ -307,7 +311,7 @@ const sd_bus_vtable cloud_connect_service_vtable[] = {
                   incoming_bus_message_callback,
                   SD_BUS_VTABLE_UNPRIVILEGED),
 
-    // com.mbed.Cloud.Connect1.GetResourcesValues
+    // com.mbed.Pelion1.Connect.GetResourcesValues
     //
     // As a Method :
     // ARRAY_of_STRUCTS(UINT32,UINT8,VARIANT) GetResourcesValues(STRING access_token,

--- a/cloud-services/mbl-cloud-client/source/cloud-connect-resource-broker/EventImmediate.cpp
+++ b/cloud-services/mbl-cloud-client/source/cloud-connect-resource-broker/EventImmediate.cpp
@@ -71,7 +71,7 @@ int EventImmediate::send()
     if (r < 0) {
         TR_ERR("sd_event_add_defer failed with error r=%d (%s) - returning %s",
                r,
-               strerror(r),
+               strerror(-r),
                MblError_to_str(MblError::DBA_SdEventCallFailure));
         return r;
     }

--- a/cloud-services/mbl-cloud-client/source/cloud-connect-resource-broker/EventManager.cpp
+++ b/cloud-services/mbl-cloud-client/source/cloud-connect-resource-broker/EventManager.cpp
@@ -36,7 +36,7 @@ MblError EventManager::init()
     if (r < 0) {
         TR_ERR("sd_event_default failed with error r=%d (%s) - returning %s",
                r,
-               strerror(r),
+               strerror(-r),
                MblError_to_str(MblError::DBA_SdEventCallFailure));
         return MblError::DBA_SdEventCallFailure;
     }
@@ -107,7 +107,7 @@ std::pair<MblError, uint64_t> EventManager::send_event_immediate(Event::EventDat
     TR_DEBUG_ENTER;
 
     if (!validate_common_event_parameters(data_type, data_length)) {
-        std::make_pair(MblError::DBA_InvalidValue, UINTMAX_MAX);
+        return std::make_pair(MblError::DBA_InvalidValue, UINTMAX_MAX);
     }
     // create the event
     std::unique_ptr<Event> ev(new EventImmediate(
@@ -137,7 +137,7 @@ std::pair<MblError, uint64_t> EventManager::send_event_periodic(Event::EventData
     TR_DEBUG_ENTER;
 
     if (!validate_periodic_event_parameters(data_type, data_length, period_millisec)) {
-        std::make_pair(MblError::DBA_InvalidValue, UINTMAX_MAX);
+        return std::make_pair(MblError::DBA_InvalidValue, UINTMAX_MAX);
     }
 
     // create the event

--- a/cloud-services/mbl-cloud-client/source/cloud-connect-resource-broker/EventPeriodic.cpp
+++ b/cloud-services/mbl-cloud-client/source/cloud-connect-resource-broker/EventPeriodic.cpp
@@ -65,7 +65,7 @@ int EventPeriodic::immediate_event_handler(sd_event_source* s,
     // http://man7.org/linux/man-pages/man2/clock_gettime.2.html
     int r = sd_event_now(ev->event_loop_handle_, CLOCK_MONOTONIC, &when_to_expire_microseconds);
     if (r < 0) {
-        TR_ERR("sd_event_add_defer failed with error r=%d (%s)", r, strerror(r));
+        TR_ERR("sd_event_add_defer failed with error r=%d (%s)", r, strerror(-r));
         return r;
     }
     // Event loop iteration has not run yet - this is not an error
@@ -90,7 +90,7 @@ int EventPeriodic::immediate_event_handler(sd_event_source* s,
     if (r < 0) {
         TR_ERR("sd_event_source_set_time failed with error r=%d (%s) - returning %s",
                r,
-               strerror(r),
+               strerror(-r),
                MblError_to_str(MblError::DBA_SdEventCallFailure));
         return r;
     }
@@ -99,7 +99,7 @@ int EventPeriodic::immediate_event_handler(sd_event_source* s,
     if (r < 0) {
         TR_ERR("sd_event_source_set_enabled failed with error r=%d (%s) - returning %s",
                r,
-               strerror(r),
+               strerror(-r),
                MblError_to_str(MblError::DBA_SdEventCallFailure));
         return r;
     }
@@ -126,7 +126,7 @@ int EventPeriodic::send()
     // clock sources refer http://man7.org/linux/man-pages/man2/clock_gettime.2.html
     int r = sd_event_now(event_loop_handle_, CLOCK_MONOTONIC, &when_to_expire_microseconds);
     if (r < 0) {
-        TR_ERR("sd_event_now failed with error r=%d (%s)", r, strerror(r));
+        TR_ERR("sd_event_now failed with error r=%d (%s)", r, strerror(-r));
         return r;
     }
     // Event loop iteration has not run yet - this is not an error
@@ -155,7 +155,7 @@ int EventPeriodic::send()
                           (void*) this);
 
     if (r < 0) {
-        TR_ERR("sd_event_add_time failed with error r=%d (%s)", r, strerror(r));
+        TR_ERR("sd_event_add_time failed with error r=%d (%s)", r, strerror(-r));
         return r;
     }
 

--- a/cloud-services/mbl-cloud-client/source/cloud-connect-resource-broker/Mailbox.cpp
+++ b/cloud-services/mbl-cloud-client/source/cloud-connect-resource-broker/Mailbox.cpp
@@ -50,9 +50,9 @@ MblError Mailbox::do_init()
     // are set with that flag
     int r = pipe2(pipefds_, O_NONBLOCK);
     if (r != 0) {
-        TR_ERR("pipe2 failed with error r=%d (%s) - returning %s",
-               r,
-               strerror(r),
+        TR_ERR("pipe2 failed with errno=%d (%s) - returning %s",
+               errno,
+               strerror(errno),
                MblError_to_str(MblError::DBA_MailBoxSystemCallFailure));
         return MblError::DBA_MailBoxSystemCallFailure;
     }
@@ -90,9 +90,9 @@ MblError Mailbox::deinit()
     if (r != 0) {
         // there is not much you can do about errors on close()
         status.set(MblError::DBA_MailBoxSystemCallFailure);
-        TR_ERR("close(pipefds_[WRITE]) failed with error r=%d (%s) - returning %s",
-               r,
-               strerror(r),
+        TR_ERR("close(pipefds_[WRITE]) failed with errno=%d (%s) - returning %s",
+               errno,
+               strerror(errno),
                status.get_status_str());
         // continue - best effort
     }
@@ -126,9 +126,9 @@ MblError Mailbox::deinit()
     if (r != 0) {
         // there is not much you can do about errors on close()
         status.set(MblError::DBA_MailBoxSystemCallFailure);
-        TR_ERR("close(pipefds_[READ]) failed with error r=%d (%s) - returning %s",
-               r,
-               strerror(r),
+        TR_ERR("close(pipefds_[READ]) failed with errno=%d (%s) - returning %s",
+               errno,
+               strerror(errno),
                status.get_status_str());
         // continue - best effort
     }
@@ -171,7 +171,7 @@ MblError Mailbox::do_poll(const int poll_fd_index, int timeout_milliseconds)
         // some ther error (no timeout)!
         TR_ERR("poll failed with error r=%d (%s) - returning %s",
                r,
-               strerror(r),
+               strerror(-r),
                MblError_to_str(MblError::DBA_MailBoxSystemCallFailure));
         return MblError::DBA_MailBoxSystemCallFailure;
     }

--- a/cloud-services/mbl-cloud-client/source/cloud-connect-resource-broker/ResourceDefinitionParser.cpp
+++ b/cloud-services/mbl-cloud-client/source/cloud-connect-resource-broker/ResourceDefinitionParser.cpp
@@ -441,7 +441,7 @@ ResourceDefinitionParser::build_object_list(const std::string& application_resou
         // Set strict mode
         builder.strictMode(&json_settings); // Init json_settings with strict mode values
 
-        // avoid failing on extra white space 
+        // avoid failing on extra white space
         json_settings["failIfExtra"] = false;
 
         builder.settings_ = json_settings;

--- a/cloud-services/mbl-cloud-client/source/cloud-connect-resource-broker/ResourceDefinitionParser.h
+++ b/cloud-services/mbl-cloud-client/source/cloud-connect-resource-broker/ResourceDefinitionParser.h
@@ -19,8 +19,9 @@
 #ifndef ResourceDefinitionParser_h_
 #define ResourceDefinitionParser_h_
 
-#include "MblError.h"
 #include "mbed-client/m2minterface.h"
+#include "MblError.h"
+
 
 #include <string>
 

--- a/cloud-services/mbl-cloud-client/tests/gtest/DBusAdapterMessagingBasicTests.cpp
+++ b/cloud-services/mbl-cloud-client/tests/gtest/DBusAdapterMessagingBasicTests.cpp
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <gtest/gtest.h>
-
 #include "DBusAdapter.h"
 #include "DBusAdapter_Impl.h"
 #include "MblError.h"
@@ -14,6 +12,10 @@
 #include "TestInfra.h"
 #include "TestInfra_DBusAdapterTester.h"
 #include "CloudConnectTrace.h"
+#include "MbedCloudClient.h"
+
+#include <gtest/gtest.h>
+#include <semaphore.h>
 
 #define TRACE_GROUP "ccrb-dbus-gtest"
 
@@ -191,123 +193,239 @@ TEST_P(ValidateRegisterResources, BasicMethodReply)
     ASSERT_EQ((uintptr_t)retval, TEST_SUCCESS);
     ASSERT_EQ(adapter.deinit(), MblError::None);
 }
-
-
 /////////////////////////////////////////////////////////////////////////////
 // DeregisterResources test
 /////////////////////////////////////////////////////////////////////////////
 
-struct DeregisterResources_entry{
-    const char *input_token_data;
-    CloudConnectStatus expected_status;
-    const char *expected_sd_bus_error_name;
-};
+// struct DeregisterResources_entry{
+//     const char *input_token_data;
+//     CloudConnectStatus expected_status;
+//     const char *expected_sd_bus_error_name;
+// };
 
-const static std::vector<DeregisterResources_entry> DeregisterResources_test_array = {
+// const static std::vector<DeregisterResources_entry> DeregisterResources_test_array = {
 
-    // string input                
-    {
-        "Return_Success",                    // input_token_data
-        STATUS_SUCCESS, /* not relevant */   // expected_status
-        "" /* not relevant */                // expected_sd_bus_error_name
-    },
+//     // string input                
+//     {
+//         "Return_Success",                    // input_token_data
+//         STATUS_SUCCESS, /* not relevant */   // expected_status
+//         "" /* not relevant */                // expected_sd_bus_error_name
+//     },
 
-    {
-        "Return_Error",                      // input_token_data
-        ERR_FIRST,    /* not relevant */     // expected_status
-        CLOUD_CONNECT_ERR_INVALID_ACCESS_TOKEN     // expected_sd_bus_error_name
-    },                             
+//     {
+//         "Return_Error",                      // input_token_data
+//         ERR_FIRST,    /* not relevant */     // expected_status
+//         CLOUD_CONNECT_ERR_INVALID_ACCESS_TOKEN     // expected_sd_bus_error_name
+//     },                             
 
-};
+// };
 
-static int AppThreadCb_validate_adapter_deregister_resources(AppThread *app_thread, void *user_data)
-{
-    TR_DEBUG_ENTER;
-    assert(app_thread);
-    assert(user_data);
+// static int AppThreadCb_validate_adapter_deregister_resources(AppThread *app_thread, void *user_data)
+// {
+//     TR_DEBUG_ENTER;
+//     assert(app_thread);
+//     assert(user_data);
     
-    AdapterParameterizedData *adapter_param_data = static_cast<AdapterParameterizedData *>(user_data);
-    const DeregisterResources_entry &test_data = DeregisterResources_test_array[adapter_param_data->test_array_index_];
+//     AdapterParameterizedData *adapter_param_data = static_cast<AdapterParameterizedData *>(user_data);
+//     const DeregisterResources_entry &test_data = DeregisterResources_test_array[adapter_param_data->test_array_index_];
 
+//     sd_bus_message *m_reply = nullptr;
+//     sd_bus_object_cleaner<sd_bus_message> reply_cleaner (m_reply, sd_bus_message_unref);
+
+//     sd_bus_error error = SD_BUS_ERROR_NULL;
+//     sd_bus_object_cleaner<sd_bus_error> error_cleaner (&error, sd_bus_error_free);
+
+//     int test_result = TEST_SUCCESS;
+//     int r = sd_bus_call_method(
+//                     app_thread->get_connection_handle(),
+//                     DBUS_CLOUD_SERVICE_NAME,
+//                     DBUS_CLOUD_CONNECT_OBJECT_PATH,
+//                     DBUS_CLOUD_CONNECT_INTERFACE_NAME,
+//                     "DeregisterResources",
+//                     &error,
+//                     &m_reply,
+//                     "s",
+//                     test_data.input_token_data);
+
+//     if (r < 0) {
+//         // message reply error gotten
+//         // compare to expected errors
+//         if(0 != strcmp(error.name, test_data.expected_sd_bus_error_name)) {
+//             TR_ERR("Actual error(%s) != Expected error(%s)", 
+//                 error.name, test_data.expected_sd_bus_error_name);
+//             set_test_result(test_result, TEST_FAILED_EXPECTED_RESULT_MISMATCH);
+//         }
+//     } else {
+//         // method reply gotten
+//         // read status and access_token
+//         uint32_t out_status = ERR_INTERNAL_ERROR;
+//         r = sd_bus_message_read(m_reply, "u", &out_status);
+//         if (r < 0) {
+//             TR_ERR("sd_bus_message_read failed(err=%d)", r);
+//             set_test_result(test_result, TEST_FAILED_SD_BUS_SYSTEM_CALL_FAILED);
+//         } else {
+//             // compare to expected 
+//             if(test_data.expected_status != out_status)
+//             {
+//                 TR_ERR("Actual status(%d) != Expected status(%d)", 
+//                     out_status, test_data.expected_status);
+//                 set_test_result(test_result, TEST_FAILED_EXPECTED_RESULT_MISMATCH);
+//             }
+//         }
+//     }
+
+//     // we stop adapter event loop from this thread instead of having one more additional thread
+//     DBusAdapter &adapter = adapter_param_data->adapater_;
+//     MblError adapter_finish_status = adapter.stop(MblError::None);
+//     if(MblError::None != adapter_finish_status)
+//     {
+//         TR_ERR("adapter->stop failed(err=%s)", MblError_to_str(adapter_finish_status));
+//         set_test_result(test_result, TEST_FAILED_ADAPTER_METHOD_FAILED);
+//     }
+
+//     return test_result;
+// }
+
+// class ValidateDeregisterResources : public testing::TestWithParam<int>{};
+// INSTANTIATE_TEST_CASE_P(AdapterParameterizedTest,
+//                         ValidateDeregisterResources,
+//                         ::testing::Range(0, (int)DeregisterResources_test_array.size(), 1));
+// TEST_P(ValidateDeregisterResources, BasicMethodReply)
+// {
+//     GTEST_LOG_START_TEST;    
+//     MessageReplyTest_ResourceBroker ccrb;
+//     DBusAdapter adapter(ccrb);
+//     ASSERT_EQ(adapter.init(), MblError::None);        
+
+//     AdapterParameterizedData userdata(adapter, (size_t)GetParam());
+
+//     AppThread app_thread(AppThreadCb_validate_adapter_deregister_resources, &userdata);
+//     ASSERT_EQ(app_thread.create(), 0);
+
+//     MblError stop_status;
+//     ASSERT_EQ(adapter.run(stop_status), MblError::None);
+
+//     void *retval = nullptr;
+//     ASSERT_EQ(app_thread.join(&retval), 0);
+//     ASSERT_EQ((uintptr_t)retval, TEST_SUCCESS);
+//     ASSERT_EQ(adapter.deinit(), MblError::None);
+// }
+
+
+/////////////////////////////////////////////////////////////////////////////
+// DBusAdapter Validate maximal allowed connections enforced
+/////////////////////////////////////////////////////////////////////////////
+
+
+
+class ResourceBrokerMock : public ResourceBroker
+{
+public:
+    virtual std::pair<CloudConnectStatus, std::string> 
+    register_resources(const IpcConnection & , 
+                       const std::string &) override
+    {
+        TR_DEBUG_ENTER; 
+        return std::make_pair(CloudConnectStatus::STATUS_SUCCESS, "");        
+    }
+};
+
+static int AppThreadCb_validate_max_allowed_connections_enforced(
+    AppThread *app_thread,
+    void * userdata)
+{
     sd_bus_message *m_reply = nullptr;
     sd_bus_object_cleaner<sd_bus_message> reply_cleaner (m_reply, sd_bus_message_unref);
+    sd_bus_error bus_error = SD_BUS_ERROR_NULL;
+    DBusAdapter *adapter = static_cast<DBusAdapter*>(userdata);
 
-    sd_bus_error error = SD_BUS_ERROR_NULL;
-    sd_bus_object_cleaner<sd_bus_error> error_cleaner (&error, sd_bus_error_free);
-
-    int test_result = TEST_SUCCESS;
+    // Call on already active connection handle. The RegisterResources callback to CCRB 
+    // is overwritten above by ResourceBrokerMock::register_resources
     int r = sd_bus_call_method(
                     app_thread->get_connection_handle(),
                     DBUS_CLOUD_SERVICE_NAME,
                     DBUS_CLOUD_CONNECT_OBJECT_PATH,
                     DBUS_CLOUD_CONNECT_INTERFACE_NAME,
-                    "DeregisterResources",
-                    &error,
+                    "RegisterResources",
+                    &bus_error,
                     &m_reply,
                     "s",
-                    test_data.input_token_data);
-
+                    "resources_definition_file_1");
     if (r < 0) {
-        // message reply error gotten
-        // compare to expected errors
-        if(0 != strcmp(error.name, test_data.expected_sd_bus_error_name)) {
-            TR_ERR("Actual error(%s) != Expected error(%s)", 
-                error.name, test_data.expected_sd_bus_error_name);
-            set_test_result(test_result, TEST_FAILED_EXPECTED_RESULT_MISMATCH);
-        }
-    } else {
-        // method reply gotten
-        // read status and access_token
-        uint32_t out_status = ERR_INTERNAL_ERROR;
-        r = sd_bus_message_read(m_reply, "u", &out_status);
-        if (r < 0) {
-            TR_ERR("sd_bus_message_read failed(err=%d)", r);
-            set_test_result(test_result, TEST_FAILED_SD_BUS_SYSTEM_CALL_FAILED);
-        } else {
-            // compare to expected 
-            if(test_data.expected_status != out_status)
-            {
-                TR_ERR("Actual status(%d) != Expected status(%d)", 
-                    out_status, test_data.expected_status);
-                set_test_result(test_result, TEST_FAILED_EXPECTED_RESULT_MISMATCH);
-            }
-        }
+        TR_ERR("sd_bus_call_method failed with r=%d (%s)", r, strerror(-r));
+        adapter->stop(MblError::None);
+        pthread_exit(reinterpret_cast<void *>(-r));
     }
 
-    // we stop adapter event loop from this thread instead of having one more additional thread
-    DBusAdapter &adapter = adapter_param_data->adapater_;
-    MblError adapter_finish_status = adapter.stop(MblError::None);
-    if(MblError::None != adapter_finish_status)
+    // Open new connection handle and send RegisterResources again
+    // This time we expect it to fail with error ERR_NUM_ALLOWED_CONNECTIONS_EXCEEDED
+    sd_bus_error_free(&bus_error);
+    bus_error = SD_BUS_ERROR_NULL;
+    sd_bus * second_connection_handle = nullptr;
+    sd_bus_object_cleaner<sd_bus> connection_cleaner (second_connection_handle, sd_bus_unref);    
+    r = sd_bus_open_user(&second_connection_handle);
+    if (r < 0){
+        TR_ERR("sd_bus_open_user failed with r=%d (%s)", r, strerror(-r));
+        adapter->stop(MblError::None);
+        pthread_exit(reinterpret_cast<void *>(-r));
+    }
+    if (nullptr == second_connection_handle){
+        TR_ERR("sd_bus_open_user failed (second_connection_handle is NULL)");
+        adapter->stop(MblError::None);
+        pthread_exit(reinterpret_cast<void *>(-1000));
+    }
+
+    r = sd_bus_call_method(
+                    second_connection_handle,
+                    DBUS_CLOUD_SERVICE_NAME,
+                    DBUS_CLOUD_CONNECT_OBJECT_PATH,
+                    DBUS_CLOUD_CONNECT_INTERFACE_NAME,
+                    "RegisterResources",
+                    &bus_error,
+                    &m_reply,
+                    "s",
+                    "resources_definition_file_2");
+    // We expect a failure with specific error code (check error code and exact error name)
+    bool b1 = r != CloudConnectStatus::ERR_NUM_ALLOWED_CONNECTIONS_EXCEEDED;
+    bool b2 = !strcmp(CLOUD_CONNECT_ERR_NUM_ALLOWED_CONNECTIONS_EXCEEDED, bus_error.name);
+    if (!b1 || !b2)        
     {
-        TR_ERR("adapter->stop failed(err=%s)", MblError_to_str(adapter_finish_status));
-        set_test_result(test_result, TEST_FAILED_ADAPTER_METHOD_FAILED);
+        TR_ERR("unexpected error code r=%d (%s) or invalid error name=%s",
+            r , strerror(-r), bus_error.name);
+        adapter->stop(MblError::None);
+        pthread_exit(reinterpret_cast<void *>(-1001));
     }
 
-    return test_result;
+    // we stop adapter event loop from this thread instead of having one more additional thread    
+    MblError status = adapter->stop(MblError::None);
+    if(MblError::None != status){
+        TR_ERR("adapter->stop failed(err=%s)", MblError_to_str(status));        
+         pthread_exit(reinterpret_cast<void *>(-1002));
+    }
+
+    sd_bus_unref(second_connection_handle);
+    return 0;
 }
 
-class ValidateDeregisterResources : public testing::TestWithParam<int>{};
-INSTANTIATE_TEST_CASE_P(AdapterParameterizedTest,
-                        ValidateDeregisterResources,
-                        ::testing::Range(0, (int)DeregisterResources_test_array.size(), 1));
-TEST_P(ValidateDeregisterResources, BasicMethodReply)
+TEST(DBusAdapterValidate2, max_allowed_connections_enforced)
 {
     GTEST_LOG_START_TEST;    
-    MessageReplyTest_ResourceBroker ccrb;
+    ResourceBrokerMock ccrb;
     DBusAdapter adapter(ccrb);
     ASSERT_EQ(adapter.init(), MblError::None);        
 
-    AdapterParameterizedData userdata(adapter, (size_t)GetParam());
-
-    AppThread app_thread(AppThreadCb_validate_adapter_deregister_resources, &userdata);
+    // Start an application thread which simulates 2 connections.
+    // First connection registers succesfully. Second connetion try to register and fails.
+    AppThread app_thread(AppThreadCb_validate_max_allowed_connections_enforced, &adapter);
     ASSERT_EQ(app_thread.create(), 0);
 
+    // run the adapter
     MblError stop_status;
     ASSERT_EQ(adapter.run(stop_status), MblError::None);
 
+    //check that  actual test on client succeeded and deinit adapter
     void *retval = nullptr;
     ASSERT_EQ(app_thread.join(&retval), 0);
-    ASSERT_EQ((uintptr_t)retval, TEST_SUCCESS);
+    ASSERT_EQ((uintptr_t)retval, MblError::None);
     ASSERT_EQ(adapter.deinit(), MblError::None);
 }
-

--- a/cloud-services/mbl-cloud-client/tests/gtest/TestInfra_DBusAdapterTester.h
+++ b/cloud-services/mbl-cloud-client/tests/gtest/TestInfra_DBusAdapterTester.h
@@ -8,6 +8,7 @@
 #define _TestInfra_DBusAdapterTester_h_
 
 #include "DBusAdapter.h"
+#include "DBusAdapter_Impl.h"
 #include "MblError.h"
 
 typedef struct sd_event sd_event;
@@ -104,6 +105,22 @@ public:
      * @return mbl::Event::EventManagerCallback
      */
     const mbl::Event::EventManagerCallback get_event_manager_callback(mbl::Event* ev) const;
+
+    /**
+     * @brief calls DBusAdapterImpl::bus_enforce_single_connection          
+     */
+    inline bool bus_enforce_single_connection(std::string& source){
+      return adapter_.impl_->bus_enforce_single_connection(source);    
+    }
+
+    /**
+     * @brief 
+     * 
+     */
+    inline int bus_track_add_dummy_sender(const char * sender){
+      adapter_.impl_->connections_tracker_.insert(make_pair(sender, nullptr));
+      return 0;    
+    }
 
 private:
     mbl::DBusAdapter& adapter_;


### PR DESCRIPTION
Tasks: IOTMBL-1687

1) Enforce single connection on adapter using already existing connections_tracker_ logic. added function DBusAdapterImpl::bus_enforce_single_connection. This can be easily removed later when
we allow more than a single connection.
2) Fix bug when returning int r when r<0,  strerror should flip the r to minus r strerror(r) changed to strerror(-r)
3) Change service name, object name and interface name (new names curry the name Pelion). 
4) Fix bug in D-Bus error pattern string. should start with com.mbed
5) Disable D-Bus method call DeregisterResourcesStatus and all relevant tests
6) Fix 2 bugs in EventManager : 2 lines did not return value, in a place they intended to return.

Tests:
Added 2 tests to check that when an 2nd connection try to send register to out service, it is denied.
All tests pass on target and Ubuntu.

Static checks:
clang-tidy - done (known issues)
clang-format - done
