### PR TITLE
Add test for IOTMBL-1606 - disconnection notifications, change D-Bus API

### DIFF
--- a/cloud-services/mbl-cloud-client/source/cloud-connect-resource-broker/DBusService.c
+++ b/cloud-services/mbl-cloud-client/source/cloud-connect-resource-broker/DBusService.c
@@ -91,6 +91,7 @@ const sd_bus_vtable cloud_connect_service_vtable[] = {
     SD_BUS_METHOD(
         "RegisterResources", "s", "us", incoming_bus_message_callback, SD_BUS_VTABLE_UNPRIVILEGED),
 
+    // TODO: This signal is disabled for now
     // com.mbed.Pelion1.Connect.RegisterResourcesStatus
     //
     // As a Signal :
@@ -106,7 +107,7 @@ const sd_bus_vtable cloud_connect_service_vtable[] = {
     //
     // ==Possible Cloud Connect Error values==
     // TBD
-    SD_BUS_SIGNAL("RegisterResourcesStatus", "u", 0),
+    // SD_BUS_SIGNAL("RegisterResourcesStatus", "u", 0),
 
     // TODO: This method call is disabled for now - upper layer does not support it as expected.
     // com.mbed.Pelion1.Connect.DeregisterResources
@@ -161,6 +162,7 @@ const sd_bus_vtable cloud_connect_service_vtable[] = {
     // TBD
     // SD_BUS_SIGNAL("DeregisterResourcesStatus", "u", 0),
 
+    // TODO: This method call is disabled for now
     // com.mbed.Pelion1.Connect.AddResourceInstances
     //
     // As a Method :
@@ -194,12 +196,13 @@ const sd_bus_vtable cloud_connect_service_vtable[] = {
     // 1            UINT32 Cloud Connect Error
     // ==Possible Cloud Connect Error values==
     // TBD
-    SD_BUS_METHOD("AddResourceInstances",
-                  "ssaq",
-                  "u",
-                  incoming_bus_message_callback,
-                  SD_BUS_VTABLE_UNPRIVILEGED),
+    // SD_BUS_METHOD("AddResourceInstances",
+    //               "ssaq",
+    //               "u",
+    //               incoming_bus_message_callback,
+    //               SD_BUS_VTABLE_UNPRIVILEGED),
 
+    // TODO: This signal is disabled for now
     // com.mbed.Pelion1.Connect.AddResourceInstancesStatus
     //
     // As a Signal :
@@ -215,8 +218,9 @@ const sd_bus_vtable cloud_connect_service_vtable[] = {
     //
     // ==Possible Cloud Connect Error values==
     // TBD
-    SD_BUS_SIGNAL("AddResourceInstancesStatus", "u", 0),
+    // SD_BUS_SIGNAL("AddResourceInstancesStatus", "u", 0),
 
+    // TODO: This method call is disabled for now
     // com.mbed.Pelion1.Connect.RemoveResourceInstances
     //
     // As a Method :
@@ -251,12 +255,13 @@ const sd_bus_vtable cloud_connect_service_vtable[] = {
     // 1            UINT32 Cloud Connect Error
     // ==Possible Cloud Connect Error values==
     // TBD
-    SD_BUS_METHOD("RemoveResourceInstances",
-                  "ssaq",
-                  "u",
-                  incoming_bus_message_callback,
-                  SD_BUS_VTABLE_UNPRIVILEGED),
+    // SD_BUS_METHOD("RemoveResourceInstances",
+    //               "ssaq",
+    //               "u",
+    //               incoming_bus_message_callback,
+    //               SD_BUS_VTABLE_UNPRIVILEGED),
 
+    // TODO: This signal is disabled for now
     // com.mbed.Pelion1.Connect.RemoveResourceInstancesStatus
     //
     // As a Signal :
@@ -272,7 +277,7 @@ const sd_bus_vtable cloud_connect_service_vtable[] = {
     //
     // ==Possible Cloud Connect Error values==
     // TBD
-    SD_BUS_SIGNAL("RemoveResourceInstancesStatus", "u", 0),
+    // SD_BUS_SIGNAL("RemoveResourceInstancesStatus", "u", 0),
 
     // com.mbed.Pelion1.Connect.SetResourcesValues
     //

--- a/cloud-services/mbl-cloud-client/source/cloud-connect-resource-broker/ResourceBroker.h
+++ b/cloud-services/mbl-cloud-client/source/cloud-connect-resource-broker/ResourceBroker.h
@@ -267,7 +267,7 @@ protected:
      * 
      * @param source - connection which has been closed
      */    
-    void notify_connection_closed(const IpcConnection & source);
+    virtual void notify_connection_closed(const IpcConnection & source);
 
     /**
      * @brief CCRB thread main function.

--- a/cloud-services/mbl-cloud-client/tests/gtest/DBusAdapterTests.cpp
+++ b/cloud-services/mbl-cloud-client/tests/gtest/DBusAdapterTests.cpp
@@ -939,7 +939,7 @@ TEST_F(DBusAdapterWithEventPeriodicTestFixture, adapter_periodic_event)
  * call succeed. Check also that length of generated token is SD_ID_128_UNIQUE_ID_LEN
  * 
  */
-TEST(DBusAdapter_AccessTokenGenerating, check_non_repeating)
+TEST(DBusAdapter, AccessTokenGenerating_check_non_repeating)
 {
     const ssize_t NUM_ITERATIONS = 100000;
     ResourceBroker broker;
@@ -958,8 +958,7 @@ TEST(DBusAdapter_AccessTokenGenerating, check_non_repeating)
     }
 }
 
-
-TEST(DBusAdapterValidate1, max_allowed_connections_enforced_unitest)
+TEST(DBusAdapter, enforce_single_connection_unit_test)
 {   
     ResourceBroker broker;    
     DBusAdapter adapter(broker);    

--- a/cloud-services/mbl-cloud-client/tests/gtest/TestInfra.h
+++ b/cloud-services/mbl-cloud-client/tests/gtest/TestInfra.h
@@ -20,6 +20,7 @@
     if (a != b) return MblError::DBA_InvalidValue
 
 enum TestResult {
+    TEST_FAILED,
     TEST_SUCCESS,
     TEST_FAILED_EXPECTED_RESULT_MISMATCH = -1,
     TEST_FAILED_SD_BUS_SYSTEM_CALL_FAILED = -2,

--- a/cloud-services/mbl-cloud-client/tests/gtest/TestInfraAppThread.cpp
+++ b/cloud-services/mbl-cloud-client/tests/gtest/TestInfraAppThread.cpp
@@ -37,11 +37,23 @@ int AppThread::start()
     TR_DEBUG_ENTER;
     int r = sd_bus_open_user(&connection_handle_);
     if (r < 0) {
+        TR_ERR("sd_bus_open_user failed with error r=%d (%s)", r, strerror(-r));
         pthread_exit((void*) -1000);
     }
     if (nullptr == connection_handle_) {
+        TR_ERR("sd_bus_open_user failed connection_handle_ is nullptr!");
         pthread_exit((void*) -1001);
     }
+
+    // Get my unique name on the bus
+    const char * unique_name = nullptr;
+    r = sd_bus_get_unique_name(connection_handle_, &unique_name);
+    if (r < 0) {
+        TR_ERR("sd_bus_get_unique_name failed with error r=%d (%s)", r, strerror(-r));
+        pthread_exit((void*) -1002);
+    }
+    assert(unique_name);
+    unique_name_.assign(unique_name);
 
     // This part must be the last
     int ret_val = user_callback_(this, user_data_);
@@ -57,14 +69,15 @@ void* AppThread::thread_main(void* app_thread)
     pthread_exit((void*) (uintptr_t) app_thread_->start());
 }
 
-int AppThread::bus_request_name(const char* name)
-{
+int AppThread::bus_request_name(const char* name) const
+{ 
     return sd_bus_request_name(connection_handle_, name, 0);
 }
 
-sd_bus *AppThread::get_connection_handle() const
+void AppThread::disconnect()
 {
-    return connection_handle_;
+    TR_DEBUG_ENTER;
+    if (connection_handle_){
+        connection_handle_ = sd_bus_flush_close_unref(connection_handle_);
+    }    
 }
-
-

--- a/cloud-services/mbl-cloud-client/tests/gtest/TestInfraAppThread.h
+++ b/cloud-services/mbl-cloud-client/tests/gtest/TestInfraAppThread.h
@@ -52,14 +52,28 @@ public:
      * @param name - name ot request
      * @return int - as in sd_bus_request_name()
      */
-    int bus_request_name(const char* name);
+    int bus_request_name(const char* name) const;
 
     /**
      * @brief return d-bus connection handle
      * 
      * @return sd_bus * d-bus connection handle
      */
-    sd_bus *get_connection_handle() const;
+    sd_bus * get_connection_handle() const { return connection_handle_; }
+
+    /**
+     * @brief Get the unique connection id
+     * 
+     * @return std::string of the unique connection id
+     */
+    std::string get_unique_connection_id() const { return unique_name_; }
+
+    /**
+     * @brief disconnect from bus and set connection_handle_ to nullptr
+     * If already disconnected, do nothing
+     * 
+     */
+    void disconnect();
 
   private:
     int start();   
@@ -77,6 +91,7 @@ public:
 
     // The thread bus connection handle
     sd_bus* connection_handle_;
+    std::string unique_name_;
 };
 
 #endif //#ifndef _TestInfraAppThread_h_


### PR DESCRIPTION
IOTMBL-1606

1) Change D-Bus API: All 4 signals are commented, add.remove resource instance commented as well. Only 3 method calls are supported now.
2) Add test which validates that the correct connection unique name is reported to CCRB.

static checks:
1) Clang tidy - passed (known issues)
2) Clang format - done

Tests:
Ubuntu - all tests  passed
Target  -  all tests passed
sample app - passed
