### PR TITLE
Fix Hello World app dockcross build environment

### DIFF
--- a/tutorials/helloworld/cc-env/arm64/Dockerfile
+++ b/tutorials/helloworld/cc-env/arm64/Dockerfile
@@ -2,14 +2,23 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-FROM dockcross/linux-arm64
+FROM dockcross/linux-arm64:20190310-7ff84ba
+
+# The following two changes to sources.list are needed because of the upstream
+# debian repository changes.
+# jessie-backports have been moved to archive.debian.org
+# https://lists.debian.org/debian-devel-announce/2019/03/msg00006.html
+# https://unix.stackexchange.com/questions/508724/failed-to-fetch-jessie-backports-repository
+RUN sed -i -e 's/ftp\.debian\.org/archive\.debian\.org/g' /etc/apt/sources.list
+# Delete jessie-updates entry because it doesn't exist anymore
+RUN sed -i -e '/jessie-updates/d' /etc/apt/sources.list
+
+# Acquire::Check-Valid-Until=false is needed because archive.debian.org is no longer being updated
+RUN apt-get -o Acquire::Check-Valid-Until=false update
 # opkg-utils uses "--sort" option of tar. This option was introduced in tar version 1.28.
 # We need to use tar from jessie-backports in order to satisfy that.
-RUN echo 'deb http://deb.debian.org/debian jessie-backports main contrib non-free' > /etc/apt/sources.list.d/jessie-backports.list && \
-	apt-get update
 RUN apt-get install -t jessie-backports tar
-RUN apt-get install wget
 RUN wget http://git.yoctoproject.org/cgit/cgit.cgi/opkg-utils/snapshot/opkg-utils-0.3.6.tar.gz && \
-	tar xvzf opkg-utils-0.3.6.tar.gz && make -C opkg-utils-0.3.6 install && \
-	rm -rf opkg-utils-0.3.6 opkg-utils-0.3.6.tar.gz
+    tar xvzf opkg-utils-0.3.6.tar.gz && make -C opkg-utils-0.3.6 install && \
+    rm -rf opkg-utils-0.3.6 opkg-utils-0.3.6.tar.gz
 ENV DEFAULT_DOCKCROSS_IMAGE linux-arm64

--- a/tutorials/helloworld/cc-env/armv7/Dockerfile
+++ b/tutorials/helloworld/cc-env/armv7/Dockerfile
@@ -2,14 +2,23 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-FROM dockcross/linux-armv7
+FROM dockcross/linux-armv7:20190310-7ff84ba
+
+# The following two changes to sources.list are needed because of the upstream
+# debian repository changes.
+# jessie-backports have been moved to archive.debian.org
+# https://lists.debian.org/debian-devel-announce/2019/03/msg00006.html
+# https://unix.stackexchange.com/questions/508724/failed-to-fetch-jessie-backports-repository
+RUN sed -i -e 's/ftp\.debian\.org/archive\.debian\.org/g' /etc/apt/sources.list
+# Delete jessie-updates entry because it doesn't exist anymore
+RUN sed -i -e '/jessie-updates/d' /etc/apt/sources.list
+
+# Acquire::Check-Valid-Until=false is needed because archive.debian.org is no longer being updated
+RUN apt-get -o Acquire::Check-Valid-Until=false update
 # opkg-utils uses "--sort" option of tar. This option was introduced in tar version 1.28.
 # We need to use tar from jessie-backports in order to satisfy that.
-RUN echo 'deb http://deb.debian.org/debian jessie-backports main contrib non-free' > /etc/apt/sources.list.d/jessie-backports.list && \
-	apt-get update
 RUN apt-get install -t jessie-backports tar
-RUN apt-get install wget
 RUN wget http://git.yoctoproject.org/cgit/cgit.cgi/opkg-utils/snapshot/opkg-utils-0.3.6.tar.gz && \
-	tar xvzf opkg-utils-0.3.6.tar.gz && make -C opkg-utils-0.3.6 install && \
-	rm -rf opkg-utils-0.3.6 opkg-utils-0.3.6.tar.gz
+    tar xvzf opkg-utils-0.3.6.tar.gz && make -C opkg-utils-0.3.6 install && \
+    rm -rf opkg-utils-0.3.6 opkg-utils-0.3.6.tar.gz
 ENV DEFAULT_DOCKCROSS_IMAGE linux-armv7


### PR DESCRIPTION
Due to upstream Debian repository changes, we need to make changes to
sources.list in the Docker image we build for cross compilation of the
Hello World app.

This fixes IOTMBL-1884