### PR TITLE
mbl-cloud-client: Fix app update not notifying Pelion after completion (#166)

### DIFF
--- a/cloud-services/mbl-cloud-client/scripts/arm_update_activate.sh
+++ b/cloud-services/mbl-cloud-client/scripts/arm_update_activate.sh
@@ -177,7 +177,22 @@ if echo "${FIRMWARE_FILES}" | grep .ipk$; then
         exit 47
     fi
     save_header_or_die "$HEADER"
-    exit 0
+
+    # mbed-cloud-client does not currently support component update; it
+    # therefore expects the system receiving the update to be rebooted as
+    # a whole image is expected to have been updated.
+    # The registration process that kicks in at boot up notifies Pelion Device
+    # Management that the update was successfully applied.
+    #
+    # Until component updates is implemented, it is required to restart the
+    # instance of the client running as service in order to simulate the
+    # expected system reboot.
+    #
+    # It was deemed safe to reboot at this stage as no other step is expected
+    # at this point other than rebooting.
+    systemctl restart mbl-cloud-client
+
+    exit "$?"
 
 elif ROOTFS_FILE=$(echo "${FIRMWARE_FILES}" | grep '^rootfs\.tar\.xz$'); then
 

--- a/cloud-services/mbl-cloud-client/source/callbacks.cpp
+++ b/cloud-services/mbl-cloud-client/source/callbacks.cpp
@@ -24,7 +24,10 @@
 
 void pal_plat_osApplicationReboot(void)
 {
-    // Hack application reboot for demo, this should ne changed later on when we have the information about the type of update in the manifest
+    // Prevent reboot in case of application update (indicated by the presence
+    // of the `do_not_reboot` file at `/tmp`).
+    // It is a temporary solution until component update is supported and the
+    // type of update package is provided in the manifest.
     FILE *fp = fopen ("/tmp/do_not_reboot", "r");
     if (fp != NULL)
     {


### PR DESCRIPTION
For IOTMBL-1926 Application update with Pelion intermittently hangs

As mbed-cloud-client currently does not support component update, a
system reboot is expected to notify Pelion Device Management that an
update was successfully applied during the registration process that
occurs at bootup. Given a system reboot for a user application update
is not desirable on Mbed Linux OS, the cloud client service is now
instead rebooted which results in the expected behavior.

This is a temporary solution until the cloud client support component
update.