### PR TITLE
Raise lava-test-raise in case of avahi discovery failure

### DIFF
--- a/ci/lava/tests/mbl-avahi-discovery-test.sh
+++ b/ci/lava/tests/mbl-avahi-discovery-test.sh
@@ -42,6 +42,7 @@ if [ -z "$mbl_device" ]
 then
     echo "ERROR - avahi-browse failed to find an MBL device"
     echo "<LAVA_SIGNAL_TESTCASE TEST_CASE_ID=AVAHI-DISCOVERY RESULT=fail>"
+    exit 255
 else
     echo "<LAVA_SIGNAL_TESTCASE TEST_CASE_ID=AVAHI-DISCOVERY RESULT=pass>"
 fi

--- a/ci/lava/tests/mbl-avahi-discovery-test.yaml
+++ b/ci/lava/tests/mbl-avahi-discovery-test.yaml
@@ -9,4 +9,4 @@ metadata:
 
 run:
     steps:
-        - ./ci/lava/tests/mbl-avahi-discovery-test.sh
+        - ./ci/lava/tests/mbl-avahi-discovery-test.sh || lava-test-raise "avahi discovery failed"


### PR DESCRIPTION
The job will fail if avahi is not able to discover the board