### PR TITLE
mbl-core:tests:open-ports-checker Remove avahi and add systemd-resolved

### DIFF
--- a/mbl-core/tests/devices/open-ports-checker/mbl/open_ports_checker/white_list.json
+++ b/mbl-core/tests/devices/open-ports-checker/mbl/open_ports_checker/white_list.json
@@ -27,10 +27,7 @@
   ],
   "executables": [
     {
-      "executable": "/usr/sbin/avahi-daemon"
-    },
-    {
-      "executable": "/usr/sbin/avahi-autoipd"
+      "executable": "/lib/systemd/systemd-resolved"
     },
     {
       "executable": "/bin/busybox.nosuid"


### PR DESCRIPTION
With the replacement of avahi-daemon with systemd-resolved for the mDNS
requests we need to update the open-ports-checker tests white list file.

Part of: IOTMBL-1919: Replace avahi with systemd mDNS capabilities

Jenkins: http://jenkins.mbed-linux.arm.com/job/ds-warrior-dev/19/
Sync: https://github.com/ARMmbed/meta-mbl/pull/522