### PR TITLE
master: sync up with warrior-dev

### DIFF
--- a/mbl-core/tests/devices/open-ports-checker/mbl/open_ports_checker/white_list.json
+++ b/mbl-core/tests/devices/open-ports-checker/mbl/open_ports_checker/white_list.json
@@ -27,10 +27,7 @@
   ],
   "executables": [
     {
-      "executable": "/usr/sbin/avahi-daemon"
-    },
-    {
-      "executable": "/usr/sbin/avahi-autoipd"
+      "executable": "/lib/systemd/systemd-resolved"
     },
     {
       "executable": "/bin/busybox.nosuid"


### PR DESCRIPTION
Commit from warrior-dev to be synced:
ff58de8 mbl-core:tests:open-ports-checker Remove avahi and add systemd-resolved