### PR TITLE
Add script to run psa-arch-tests

### DIFF
--- a/ci/lava/tests/psa-arch-tests.py
+++ b/ci/lava/tests/psa-arch-tests.py
@@ -3,21 +3,19 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-""" Script to run psa-arch-tests.
+"""
+Script to run psa-arch-tests.
 
 The actual tests should already be on the target, this script just runs them
 via mbl-cli and translates the output into something LAVA can understand.
 """
-
 import re
 import subprocess
 import sys
 
-SUITES = [ "crypto" ]
+SUITES = ["crypto"]
 
-EXPECTED_FAILS = {
-    "239_Testing_crypto_asymmetric_APIs": True,
-}
+EXPECTED_FAILS = {"239_Testing_crypto_asymmetric_APIs": True}
 
 
 def _get_id_from_line(line):
@@ -27,8 +25,10 @@ def _get_id_from_line(line):
     numeric_id, description = match.group("numeric_id", "description")
     return "{}_{}".format(
         match.group("numeric_id"),
-        _get_id_from_line.subs_pattern.sub("_", match.group("description"))
+        _get_id_from_line.subs_pattern.sub("_", match.group("description")),
     )
+
+
 _get_id_from_line.match_pattern = re.compile(
     r"""
         ^ \s*
@@ -37,18 +37,22 @@ _get_id_from_line.match_pattern = re.compile(
         DESCRIPTION: \s* (?P<description>.*\S)
         \s* $
     """,
-    flags=re.VERBOSE
+    flags=re.VERBOSE,
 )
 _get_id_from_line.subs_pattern = re.compile("[^A-Za-z0-9_]+")
+
 
 def _get_result_from_line(line):
     match = _get_result_from_line.pattern.match(line)
     if not match:
         return None
     return match.group("result")
+
+
 _get_result_from_line.pattern = re.compile(
     r"^\s*TEST RESULT:\s*(?P<result>PASS|FAIL|SKIP)"
 )
+
 
 def _check_expected_fails(current_id, result):
     """
@@ -67,6 +71,7 @@ def _check_expected_fails(current_id, result):
             return "fail"
     return result
 
+
 def _report_result(current_id, result):
     if not current_id:
         current_id = "unknown"
@@ -75,15 +80,14 @@ def _report_result(current_id, result):
 
     print(
         "<LAVA_SIGNAL_TESTCASE TEST_CASE_ID={} RESULT={}>".format(
-            current_id,
-            result
+            current_id, result
         )
     )
 
+
 def _get_dut_addr():
     list_output = subprocess.check_output(
-        ["mbl-cli", "list"],
-        universal_newlines=True
+        ["mbl-cli", "list"], universal_newlines=True
     )
     for line in list_output.splitlines():
         print(line)
@@ -91,14 +95,23 @@ def _get_dut_addr():
         if match:
             return match.group("address")
     return None
+
+
 _get_dut_addr.pattern = re.compile(r"\s*1:[^:]+:\s+(?P<address>\S+)")
+
 
 def _run_suite(suite, dut_addr):
     with subprocess.Popen(
-        ["mbl-cli", "--address", dut_addr, "shell", "psa-arch-{}-tests".format(suite)],
+        [
+            "mbl-cli",
+            "--address",
+            dut_addr,
+            "shell",
+            "psa-arch-{}-tests".format(suite),
+        ],
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
-        universal_newlines=True
+        universal_newlines=True,
     ) as proc:
         current_id = None
         for line in proc.stdout:
@@ -112,6 +125,7 @@ def _run_suite(suite, dut_addr):
             if result:
                 _report_result(current_id, result)
                 current_id = None
+
 
 dut_addr = _get_dut_addr()
 if not dut_addr:

--- a/ci/lava/tests/psa-arch-tests.py
+++ b/ci/lava/tests/psa-arch-tests.py
@@ -15,7 +15,16 @@ import sys
 
 SUITES = ["crypto"]
 
-EXPECTED_FAILS = {"239_Testing_crypto_asymmetric_APIs": True}
+# Tests that we know will fail.
+#
+# These will be reported to Lava as skipped when they fail so that engineers
+# don't waste time investigating the failures. If the tests actually pass then
+# they will be reported to Lava as failures so that we notice and update this
+# list.
+EXPECTED_FAILS = {
+    # Bug in mbed-crypto: https://github.com/ARMmbed/mbed-crypto/issues/126
+    "239_Testing_crypto_asymmetric_APIs": True
+}
 
 
 def _get_id_from_line(line):

--- a/ci/lava/tests/psa-arch-tests.py
+++ b/ci/lava/tests/psa-arch-tests.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+# Copyright (c) 2019 Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+""" Script to run psa-arch-tests.
+
+The actual tests should already be on the target, this script just runs them
+via mbl-cli and translates the output into something LAVA can understand.
+"""
+
+import re
+import subprocess
+import sys
+
+SUITES = [ "crypto" ]
+
+EXPECTED_FAILS = {
+    "239_Testing_crypto_asymmetric_APIs": True,
+}
+
+
+def _get_id_from_line(line):
+    match = _get_id_from_line.match_pattern.match(line)
+    if not match:
+        return None
+    numeric_id, description = match.group("numeric_id", "description")
+    return "{}_{}".format(
+        match.group("numeric_id"),
+        _get_id_from_line.subs_pattern.sub("_", match.group("description"))
+    )
+_get_id_from_line.match_pattern = re.compile(
+    r"""
+        ^ \s*
+        TEST: \s* (?P<numeric_id>\d+)
+        \s* \| \s*
+        DESCRIPTION: \s* (?P<description>.*\S)
+        \s* $
+    """,
+    flags=re.VERBOSE
+)
+_get_id_from_line.subs_pattern = re.compile("[^A-Za-z0-9_]+")
+
+def _get_result_from_line(line):
+    match = _get_result_from_line.pattern.match(line)
+    if not match:
+        return None
+    return match.group("result")
+_get_result_from_line.pattern = re.compile(
+    r"^\s*TEST RESULT:\s*(?P<result>PASS|FAIL|SKIP)"
+)
+
+def _check_expected_fails(current_id, result):
+    """
+    Modify result to trick LAVA about expected failures.
+
+    This is a hack because LAVA doesn't support "expected fail" results. If an
+    "expected fail" test fails, tell LAVA it was skipped so that it doesn't
+    cause much fuss. If the test succeeds, lie to LAVA and say it failed. This
+    should cause somebody to look into the failure and maybe remove it from the
+    EXPECTED_FAILS list.
+    """
+    if current_id in EXPECTED_FAILS:
+        if result == "fail":
+            return "skip"
+        else:
+            return "fail"
+    return result
+
+def _report_result(current_id, result):
+    if not current_id:
+        current_id = "unknown"
+
+    result = _check_expected_fails(current_id, result.lower())
+
+    print(
+        "<LAVA_SIGNAL_TESTCASE TEST_CASE_ID={} RESULT={}>".format(
+            current_id,
+            result
+        )
+    )
+
+def _get_dut_addr():
+    list_output = subprocess.check_output(
+        ["mbl-cli", "list"],
+        universal_newlines=True
+    )
+    for line in list_output.splitlines():
+        print(line)
+        match = _get_dut_addr.pattern.match(line)
+        if match:
+            return match.group("address")
+    return None
+_get_dut_addr.pattern = re.compile(r"\s*1:[^:]+:\s+(?P<address>\S+)")
+
+def _run_suite(suite, dut_addr):
+    with subprocess.Popen(
+        ["mbl-cli", "--address", dut_addr, "shell", "psa-arch-{}-tests".format(suite)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        universal_newlines=True
+    ) as proc:
+        current_id = None
+        for line in proc.stdout:
+            line = line.strip()
+            print(line)
+            test_id = _get_id_from_line(line)
+            if test_id:
+                current_id = test_id
+                continue
+            result = _get_result_from_line(line)
+            if result:
+                _report_result(current_id, result)
+                current_id = None
+
+dut_addr = _get_dut_addr()
+if not dut_addr:
+    _report_result("get_dut_addr", "FAIL")
+    sys.exit(1)
+
+for suite in SUITES:
+    _run_suite(suite, dut_addr)
+
+sys.exit(0)

--- a/ci/lava/tests/psa-arch-tests.yaml
+++ b/ci/lava/tests/psa-arch-tests.yaml
@@ -1,0 +1,20 @@
+# Copyright (c) 2019, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+metadata:
+    format: Lava-Test Test Definition 1.0
+    name: PSA arch tests
+    description: Run PSA arch tests
+
+    parameters:
+        #
+        # virtual_env: specifies the Python virtual environment
+        #
+        virtual_env:
+
+run:
+    steps:
+        - . $virtual_env/bin/activate
+        - ./ci/lava/tests/psa-arch-tests.py || lava-test-raise "psa-arch-tests failed"
+


### PR DESCRIPTION
For IOTMBL-2147: Create recipe for psa-arch-tests

**Related PRs**
* https://github.com/ARMmbed/meta-mbl/pull/598 (to add psa-arch-tests recipe).
* second meta-mbl PR coming soon (to update the mbl-core SRCREV after this PR is merged). 
* https://github.com/ARMmbed/mbl-tools/pull/246 (to add a Lava test plan to run the script from this PR). 
* https://github.com/ARMmbed/mbl-jenkins/pull/111 (to add the new test plan to the warrior-dev Jenkins build). 

**Jenkins and Lava links**
* See https://github.com/ARMmbed/meta-mbl/pull/598