### PR TITLE
Refactor rootfs-update scripts

### DIFF
--- a/ci/lava/tests/rootfs-update.yaml
+++ b/ci/lava/tests/rootfs-update.yaml
@@ -13,6 +13,11 @@ parameters:
     #
     test_stage:
 
+    # rootfs: specifies the active rootfs that needs to checked. It is the
+    #         label of the root file system (e.g.: rootfs1)
+    #
+    rootfs:
+
     # image_url: specifies the url of the test image in order to extract the
     #            root_fs image
     #
@@ -29,4 +34,4 @@ parameters:
 
 run:
     steps:
-        - ./ci/lava/tests/rootfs-update.sh --venv $virtual_env --stage $test_stage --image $image_url --update $pelion_update
+        - ./ci/lava/tests/rootfs-update.sh --venv $virtual_env --stage $test_stage --image $image_url --rootfs $rootfs --update $pelion_update


### PR DESCRIPTION
The refactor is needed because the script now doesn't assume the state
of the board. The rootfs to check is passed as argument by the parent
process (e.g.: LAVA pipeline which knows the state of the DUT)

Related ticket: IOTMBL-2258