### PR TITLE
Merge feature-partitioning into warrior-dev

### DIFF
--- a/cloud-services/mbl-cloud-client/scripts/CMakeLists.txt
+++ b/cloud-services/mbl-cloud-client/scripts/CMakeLists.txt
@@ -1,0 +1,30 @@
+# Copyright (c) 2019 ARM Ltd.
+#
+# SPDX-License-Identifier: Apache-2.0
+# Licensed under the Apache License, Version 2.0 (the License); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an AS IS BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set(BOOTFLAGS_DIR "/var/bootflags" CACHE PATH "Path to directory containing boot flag files")
+set(TMP_DIR "/tmp" CACHE PATH "Path to directory used to temporarily store small files")
+set(UPDATE_PAYLOAD_DIR "/tmp" CACHE PATH "Path to directory used to temporarily store update payload files")
+set(LOG_DIR "/var/log" CACHE FILEPATH "Path to directory in which to write log files")
+set(ROOTFS1_LABEL "rootfs1" CACHE STRING "Label used for the first root file system bank")
+set(ROOTFS2_LABEL "rootfs2" CACHE STRING "Label used for the second root file system bank")
+set(ROOTFS_TYPE "ext4" CACHE STRING "Type of file system used for root file systems")
+
+# Replace config value placeholders with values from CMake variables.
+configure_file("arm_update_common.sh.in" "arm_update_common.sh" @ONLY)
+
+# We don't currently need to do any placeholder replacement in these scripts,
+# but for consistency, copy them to the build directory.
+configure_file("arm_update_activate.sh" "arm_update_activate.sh" COPYONLY)
+configure_file("arm_update_active_details.sh" "arm_update_active_details.sh" COPYONLY)

--- a/cloud-services/mbl-cloud-client/scripts/arm_update_active_details.sh
+++ b/cloud-services/mbl-cloud-client/scripts/arm_update_active_details.sh
@@ -49,12 +49,6 @@ HEADER_NAME="header"
 # location where the update client will find the header
 HEADER_PATH="${HEADER_DIR}/${HEADER_NAME}.bin"
 
-# Flag partition
-FLAGS=$(get_device_for_label bootflags)
-exit_on_error "$?"
-
-ensure_mounted_or_die "$FLAGS" /mnt/flags "$FLAGSFS_TYPE"
-
 # Boot Flags
 if [ -e "$SAVED_HEADER_PATH" ]; then
     if ! cp "$SAVED_HEADER_PATH" "$HEADER_PATH"; then

--- a/cloud-services/mbl-cloud-client/scripts/arm_update_common.sh.in
+++ b/cloud-services/mbl-cloud-client/scripts/arm_update_common.sh.in
@@ -19,10 +19,17 @@
 # Note - this library file uses return and exit codes 1-20 to indicate errors.
 #
 
-LOCAL_CONFIG_PATH=/opt/arm/arm_update_local_config.sh
-ROOTFS_TYPE="ext4"
-FLAGSFS_TYPE="ext4"
-SAVED_HEADER_PATH="/mnt/flags/header"
+FLAGS_DIR="@BOOTFLAGS_DIR@"
+TMP_DIR="@TMP_DIR@"
+UPDATE_PAYLOAD_DIR="@UPDATE_PAYLOAD_DIR@"
+LOG_DIR="@LOG_DIR@"
+ROOTFS1_LABEL="@ROOTFS1_LABEL@"
+ROOTFS2_LABEL="@ROOTFS2_LABEL@"
+ROOTFS_TYPE="@ROOTFS_TYPE@"
+
+ARM_UPDATE_ACTIVATE_LOG_PATH="${LOG_DIR}/arm_update_activate.log"
+ARM_UPDATE_ACTIVE_DETAILS_LOG_PATH="${LOG_DIR}/arm_update_active_details.log"
+SAVED_HEADER_PATH="${FLAGS_DIR}/header"
 
 # Given an exit status, exits with that status if it is non-zero, otherwise
 # does nothing
@@ -130,6 +137,3 @@ emodFsType="$3"
 get_active_root_device() {
     lsblk -nrpo NAME,MOUNTPOINT | grep -e ".* /$" | cut -d ' ' -f1
 }
-
-
-[ -e "$LOCAL_CONFIG_PATH" ] && . "$LOCAL_CONFIG_PATH"


### PR DESCRIPTION
We have a 0.8 branch now so merge feature-partitioning into warrior-dev.

The branch contains a single commit on top of warrior-dev:
```
Add mechanism to configure values in update scripts

In MBL we're going to get rid of the bootflags partition and move our
boot flag files somewhere else. Unfortunately the firmware update
scripts assumed that the directory containing the bootflags was a mount
point and they hardcoded the path to this directory.

We previously had a mechanism to source a "local config script" in to
the update scripts, but this was a hack and I don't want to extend it.
Instead, use CMake's file configuration mechanism to allow distro
specific values to be injected into the scripts during a build.
```

**Related PRs**
https://github.com/ARMmbed/meta-mbl/pull/640