### PR TITLE
Enable wifi on imx6ul

### DIFF
--- a/ci/lava/dependencies/enable-wifi.sh
+++ b/ci/lava/dependencies/enable-wifi.sh
@@ -51,8 +51,7 @@ mbl_command="mbl-cli -a $dut_address"
 
 if [ "$device_type" = "imx7s-warp-mbl" ] || \
    [ "$device_type" = "bcm2837-rpi-3-b-32" ] || \
-   [ "$device_type" = "bcm2837-rpi-3-b-plus-32" ] || \
-   [ "$device_type" = "imx6ul-pico-mbl" ]
+   [ "$device_type" = "bcm2837-rpi-3-b-plus-32" ]
 then
 
 
@@ -72,7 +71,9 @@ then
 
         printf "<LAVA_SIGNAL_TESTCASE TEST_CASE_ID=enable-wifi RESULT=pass>\n"
     fi
-elif [ "$device_type" =  "imx7d-pico-mbl" ] || [ "$device_type" =  "imx8mmevk-mbl" ]
+elif [ "$device_type" = "imx7d-pico-mbl" ] || \
+     [ "$device_type" = "imx8mmevk-mbl" ]  || \
+     [ "$device_type" = "imx6ul-pico-mbl" ]
 then
 
 


### PR DESCRIPTION
The imx6ul should be treated the same as the imx7d and imx8 as it has the same qualcomm chipset. 