### PR TITLE
Pass local.conf to pytest.

### DIFF
--- a/ci/lava/conftest.py
+++ b/ci/lava/conftest.py
@@ -45,7 +45,7 @@ def pytest_addoption(parser):
     parser.addoption(
         "--host-tutorials-dir", action="store", default="/tmp/tutorials"
     )
-    parser.addoption("--local-conf-url", action="store", default="")
+    parser.addoption("--local-conf-file", action="store", default="")
     parser.addoption("--payload-version", action="store", default="1")
     parser.addoption("--venv", action="store", default="/tmp/venv")
 
@@ -133,12 +133,19 @@ def host_tutorials_dir(request):
 @pytest.fixture
 def local_conf_file(request):
     """
-    Fixture for --local-conf-url.
+    Fixture for --local-conf-file.
 
-    Downloads the file from the url and returns the path, or None if the
-    download fails.
+    If the provided option starts with http, atttempt to download the file
+    from the url and return the path.
+    If the provided option is a file that exists then return that path.
+    Else return None
     """
-    return _download_from_url(request.config.getoption("--local-conf-url"))
+    if request.config.getoption("--local-conf-file").startswith("http"):
+        return _download_from_url(request.config.getoption("--local-conf-file"))
+    elif os.path.exists(request.config.getoption("--local-conf-file")):
+        return request.config.getoption("--local-conf-file")
+    else:
+        return None
 
 
 @pytest.fixture

--- a/ci/lava/conftest.py
+++ b/ci/lava/conftest.py
@@ -54,7 +54,7 @@ def _download_from_url(url):
 
     filename = None
 
-    if url != "":
+    if url:
 
         filename = os.path.join(tempfile.mkdtemp(), os.path.basename(url))
 

--- a/ci/lava/conftest.py
+++ b/ci/lava/conftest.py
@@ -141,7 +141,9 @@ def local_conf_file(request):
     Else return None
     """
     if request.config.getoption("--local-conf-file").startswith("http"):
-        return _download_from_url(request.config.getoption("--local-conf-file"))
+        return _download_from_url(
+            request.config.getoption("--local-conf-file")
+        )
     elif os.path.exists(request.config.getoption("--local-conf-file")):
         return request.config.getoption("--local-conf-file")
     else:

--- a/ci/lava/conftest.py
+++ b/ci/lava/conftest.py
@@ -32,21 +32,21 @@ def pytest_report_teststatus(report):
 
 def pytest_addoption(parser):
     """Add option parsing to pytest."""
-    parser.addoption("--debug_output", action="store_true")
+    parser.addoption("--debug-output", action="store_true")
     parser.addoption("--device", action="store", default="none")
     parser.addoption("--dut", action="store", default="auto")
     parser.addoption(
-        "--dut_download_dir", action="store", default="/tmp/pytest"
+        "--dut-download-dir", action="store", default="/tmp/pytest"
     )
-    parser.addoption("--dut_tutorials_dir", action="store", default="/scratch")
+    parser.addoption("--dut-tutorials-dir", action="store", default="/scratch")
     parser.addoption(
-        "--host_download_dir", action="store", default="/tmp/pytest"
+        "--host-download-dir", action="store", default="/tmp/pytest"
     )
     parser.addoption(
-        "--host_tutorials_dir", action="store", default="/tmp/tutorials"
+        "--host-tutorials-dir", action="store", default="/tmp/tutorials"
     )
-    parser.addoption("--local_conf_url", action="store", default="")
-    parser.addoption("--payload_version", action="store", default="1")
+    parser.addoption("--local-conf-url", action="store", default="")
+    parser.addoption("--payload-version", action="store", default="1")
     parser.addoption("--venv", action="store", default="/tmp/venv")
 
 
@@ -90,8 +90,8 @@ def _download_from_url(url):
 
 @pytest.fixture
 def debug_output(request):
-    """Fixture for --debug_output."""
-    return request.config.getoption("--debug_output")
+    """Fixture for --debug-output."""
+    return request.config.getoption("--debug-output")
 
 
 @pytest.fixture
@@ -108,38 +108,43 @@ def dut(request):
 
 @pytest.fixture
 def dut_download_dir(request):
-    """Fixture for --dut_download_dir."""
-    return request.config.getoption("--dut_download_dir")
+    """Fixture for --dut-download-dir."""
+    return request.config.getoption("--dut-download-dir")
 
 
 @pytest.fixture
 def dut_tutorials_dir(request):
-    """Fixture for --dut_tutorials_dir."""
-    return request.config.getoption("--dut_tutorials_dir")
+    """Fixture for --dut-tutorials-dir."""
+    return request.config.getoption("--dut-tutorials-dir")
 
 
 @pytest.fixture
 def host_download_dir(request):
-    """Fixture for --host_download_dir."""
-    return request.config.getoption("--host_download_dir")
+    """Fixture for --host-download-dir."""
+    return request.config.getoption("--host-download-dir")
 
 
 @pytest.fixture
 def host_tutorials_dir(request):
-    """Fixture for --host_tutorials_dir."""
-    return request.config.getoption("--host_tutorials_dir")
+    """Fixture for --host-tutorials-dir."""
+    return request.config.getoption("--host-tutorials-dir")
 
 
 @pytest.fixture
-def local_conf_url(request):
-    """Fixture for --local_conf_url."""
-    return _download_from_url(request.config.getoption("--local_conf_url"))
+def local_conf_file(request):
+    """
+    Fixture for --local-conf-url.
+
+    Downloads the file from the url and returns the path, or None if the
+    download fails.
+    """
+    return _download_from_url(request.config.getoption("--local-conf-url"))
 
 
 @pytest.fixture
 def payload_version(request):
-    """Fixture for --payload_version."""
-    return request.config.getoption("--payload_version")
+    """Fixture for --payload-version."""
+    return request.config.getoption("--payload-version")
 
 
 @pytest.fixture
@@ -155,7 +160,7 @@ class ExecuteHelper:
 
     def __init__(self, request):
         """Initialise the class."""
-        ExecuteHelper.debug = request.config.getoption("--debug_output")
+        ExecuteHelper.debug = request.config.getoption("--debug-output")
 
     @staticmethod
     def _print(data):

--- a/ci/lava/dependencies/create-python-environment-on-device.yaml
+++ b/ci/lava/dependencies/create-python-environment-on-device.yaml
@@ -31,7 +31,7 @@ run:
         - set +e
 
         # Run pytest to create an environment on the device under test
-        - pytest -s --verbose ./ci/lava/dependencies/test-install-pytest-to-target.py --venv $virtual_env --host_download_dir $host_download_dir --dut_download_dir $dut_download_dir
+        - pytest -s --verbose ./ci/lava/dependencies/test-install-pytest-to-target.py --venv $virtual_env --host-download-dir $host_download_dir --dut-download-dir $dut_download_dir
 
         # Reenable the "-e" option
         - set -e

--- a/ci/lava/tests/build-tutorial-images.yaml
+++ b/ci/lava/tests/build-tutorial-images.yaml
@@ -39,4 +39,4 @@ run:
         - chmod -R a+w tutorials
 
         # Build the Hello World sample app.
-        - su ubuntu -c "$virtual_env/bin/pytest --verbose -s ./ci/lava/tests/test-build-tutorial-images.py --device $device --host_tutorials_dir $host_tutorials_dir --payload_version $payload_version"
+        - su ubuntu -c "$virtual_env/bin/pytest --verbose -s ./ci/lava/tests/test-build-tutorial-images.py --device $device --host-tutorials-dir $host_tutorials_dir --payload-version $payload_version"

--- a/ci/lava/tests/core-component.yaml
+++ b/ci/lava/tests/core-component.yaml
@@ -30,5 +30,5 @@ run:
         # Activate virtual environment
         - . $virtual_env/bin/activate
 
-        - pytest --verbose -s ./ci/lava/tests/test-core-component.py --venv $virtual_env --host-tutorials-dir $host_tutorials_dir --dut-tutorials-dir $dut_tutorials_dir --local-conf-url $local_conf_url
+        - pytest --verbose -s ./ci/lava/tests/test-core-component.py --venv $virtual_env --host-tutorials-dir $host_tutorials_dir --dut-tutorials-dir $dut_tutorials_dir --local-conf-file $local_conf_url
 

--- a/ci/lava/tests/core-component.yaml
+++ b/ci/lava/tests/core-component.yaml
@@ -21,10 +21,14 @@ parameters:
     #
     virtual_env:
 
+    # local_conf_url: specifies the url of the local.conf file
+    #
+    local_conf_url:
+
 run:
     steps:
         # Activate virtual environment
         - . $virtual_env/bin/activate
 
-        - pytest --verbose -s ./ci/lava/tests/test-core-component.py --venv $virtual_env --host_tutorials_dir $host_tutorials_dir --dut_tutorials_dir $dut_tutorials_dir
+        - pytest --verbose -s ./ci/lava/tests/test-core-component.py --venv $virtual_env --host_tutorials_dir $host_tutorials_dir --dut_tutorials_dir $dut_tutorials_dir --local_conf_url $local_conf_url
 

--- a/ci/lava/tests/core-component.yaml
+++ b/ci/lava/tests/core-component.yaml
@@ -30,5 +30,5 @@ run:
         # Activate virtual environment
         - . $virtual_env/bin/activate
 
-        - pytest --verbose -s ./ci/lava/tests/test-core-component.py --venv $virtual_env --host_tutorials_dir $host_tutorials_dir --dut_tutorials_dir $dut_tutorials_dir --local_conf_url $local_conf_url
+        - pytest --verbose -s ./ci/lava/tests/test-core-component.py --venv $virtual_env --host-tutorials-dir $host_tutorials_dir --dut-tutorials-dir $dut_tutorials_dir --local-conf-url $local_conf_url
 

--- a/ci/lava/tests/test-build-tutorial-images.py
+++ b/ci/lava/tests/test-build-tutorial-images.py
@@ -31,24 +31,10 @@ MULTI_APP_ONE_FAIL_INSTALL_TAR = (
 )
 
 
-class Test_Build_Test_Images:
+class TestBuildTestImages:
     """Class to encapsulate building images for testing."""
 
-    def _print_result(self, teststep, err):
-        """Private function to provide LAVA formatted sub-results."""
-        if err == 0:
-            print(
-                "<LAVA_SIGNAL_TESTCASE TEST_CASE_ID={}-{} RESULT=pass>".format(
-                    self.__class__.__name__, teststep
-                )
-            )
-        else:
-            print(
-                "<LAVA_SIGNAL_TESTCASE TEST_CASE_ID={}-{} RESULT=fail>".format(
-                    self.__class__.__name__, teststep
-                )
-            )
-        return err
+    arm_arch = None
 
     def _replace_line_in_file(self, filename, search, replace):
         """
@@ -76,15 +62,9 @@ class Test_Build_Test_Images:
         with open(filename, "w") as fout:
             fout.writelines(data[1:])
 
-    def test_build(self, device, execute_helper, host_tutorials_dir):
-        """
-        Build all of the images and tarballs.
-
-        This function builds the the dockcross compiler and the test images
-        needed for mbl-core tests and the HelloWorld update tests.
-        """
+    def test_select_architecture(self, device):
+        """Select the architechture based upon the device under test."""
         err = 0
-        overall_err = 0
 
         if (
             device == "bcm2837-rpi-3-b-32"
@@ -93,20 +73,17 @@ class Test_Build_Test_Images:
             or device == "imx7d-pico-mbl"
             or device == "imx6ul-pico-mbl"
         ):
-            arm_arch = "armv7"
+            TestBuildTestImages.arm_arch = "armv7"
         elif device == "imx8mmevk-mbl":
-            arm_arch = "arm64"
+            TestBuildTestImages.arm_arch = "arm64"
         else:
             print("Unsupported device type {}".format(device))
             err = 1
 
-        overall_err += self._print_result("select-device", err)
+        assert err == 0
 
-        # If a valid device isn't specifed then exit with an error.
-        if err == 1:
-            assert False
-            return
-
+    def test_build_dockcross(self, execute_helper):
+        """Build the dockcross compiler."""
         os.chdir("tutorials/helloworld/")
 
         # Build dockcross
@@ -115,180 +92,218 @@ class Test_Build_Test_Images:
                 "docker",
                 "build",
                 "-t",
-                "linux-" + arm_arch + ":latest",
-                "./cc-env/" + arm_arch,
+                "linux-" + TestBuildTestImages.arm_arch + ":latest",
+                "./cc-env/" + TestBuildTestImages.arm_arch,
             ]
         )
 
-        overall_err += self._print_result("build-dockcross", err)
-        if err != 0:
-            assert False
-            return
+        assert err == 0
 
+    def test_run_dockcross(self, execute_helper):
+        """
+        Run the dockcross compiler.
+
+        This produces a script that is used to build the images.
+        """
         err, output, error = execute_helper.execute_command(
-            ["docker", "run", "--rm", "linux-" + arm_arch]
+            ["docker", "run", "--rm", "linux-" + TestBuildTestImages.arm_arch]
         )
-        overall_err += self._print_result("run-dockcross", err)
 
         if err != 0:
             assert False
             return
         else:
             print("Creating build file")
-            build = open("build-{}".format(arm_arch), "w")
+            build = open("build-{}".format(TestBuildTestImages.arm_arch), "w")
             build.write(output)
             build.close()
-            os.chmod("build-{}".format(arm_arch), 0o777)
+            os.chmod("build-{}".format(TestBuildTestImages.arm_arch), 0o777)
             print("Created build file")
 
-            print("Create User Sample App")
-            err, output, error = execute_helper.execute_command(
-                ["./build-{}".format(arm_arch), "make", "release"]
-            )
-            overall_err += self._print_result("build-application", err)
+        assert err == 0
 
-            print("Create Good Sample Apps")
-            for image in range(1, 6):
-                self._replace_line_in_file(
-                    "src_opkg/CONTROL/control",
-                    "Package:",
-                    "sample-app-{}-good".format(image),
-                )
+    def test_build_images(self, execute_helper):
+        """Build all of the test images."""
+        overall_result = 0
 
-                err, output, error = execute_helper.execute_command(
-                    ["./build-{}".format(arm_arch), "make", "release"]
-                )
-                overall_err += self._print_result(
-                    "build-sample-app-{}-good".format(image), err
-                )
+        print("\nCreate User Sample App")
+        err, output, error = execute_helper.execute_command(
+            [
+                "./build-{}".format(TestBuildTestImages.arm_arch),
+                "make",
+                "release",
+            ]
+        )
 
-            print("Create Bad Architecture App")
-            self._replace_line_in_file(
-                "src_opkg/CONTROL/control", "Package:", BAD_ARCHITECTURE_IMAGE
-            )
-            self._replace_line_in_file(
-                "src_opkg/CONTROL/control", "Version:", "1.1"
-            )
+        overall_result += err
+
+        print("Create Good Sample Apps")
+        for image in range(1, 6):
             self._replace_line_in_file(
                 "src_opkg/CONTROL/control",
-                "Architecture:",
-                "invalid-architecture",
+                "Package:",
+                "sample-app-{}-good".format(image),
             )
 
-            err, output, error = execute_helper.execute_command(
-                ["./build-{}".format(arm_arch), "make", "release"]
-            )
-            overall_err += self._print_result(
-                "build-{}".format(BAD_ARCHITECTURE_IMAGE), err
-            )
-
-            print("Create Bad OCI Runtime App")
-            self._replace_line_in_file(
-                "src_opkg/CONTROL/control", "Package:", BAD_RUNTIME_IMAGE
-            )
-            self._replace_line_in_file(
-                "src_opkg/CONTROL/control", "Architecture:", "any"
-            )
-            self._remove_first_line_from_file("src_bundle/config.json")
-
-            err, output, error = execute_helper.execute_command(
-                ["./build-{}".format(arm_arch), "make", "release"]
-            )
-            overall_err += self._print_result(
-                "build-{}".format(BAD_RUNTIME_IMAGE), err
-            )
-
-            # Navigate to the location of the IPK
-            os.chdir("release/ipk/")
-
-            # Create tar bundles
-            if not os.path.exists(host_tutorials_dir):
-                os.makedirs(host_tutorials_dir)
-
-            # User Sample App is needed in both ipk and tar format
-            err, output, error = execute_helper.execute_command(
-                [
-                    "cp",
-                    "user-sample-app-package_1.0_any.ipk",
-                    "{}/user-sample-app-package_1.0_any.ipk".format(
-                        host_tutorials_dir
-                    ),
-                ]
-            )
-            overall_err += self._print_result(
-                "copy-user-sample-app-package_1.0_any.ipk", err
-            )
+            print("\tBuilding sample-app-{}-good".format(image))
 
             err, output, error = execute_helper.execute_command(
                 [
-                    "tar",
-                    "-cvf",
-                    "{}/{}".format(host_tutorials_dir, USER_SAMPLE_TAR),
-                    "user-sample-app-package_1.0_any.ipk",
+                    "./build-{}".format(TestBuildTestImages.arm_arch),
+                    "make",
+                    "release",
                 ]
             )
-            overall_err += self._print_result(
-                "tar-{}".format(USER_SAMPLE_TAR), err
-            )
 
-            # Create tar bundle with 5 good apps.
-            err, output, error = execute_helper.execute_command(
-                [
-                    "tar",
-                    "-cf",
-                    "{}/{}".format(host_tutorials_dir, MULTI_APP_ALL_GOOD_TAR),
-                    "sample-app-1-good_1.0_any.ipk",
-                    "sample-app-2-good_1.0_any.ipk",
-                    "sample-app-3-good_1.0_any.ipk",
-                    "sample-app-4-good_1.0_any.ipk",
-                    "sample-app-5-good_1.0_any.ipk",
-                ]
-            )
-            overall_err += self._print_result(
-                "tar-{}".format(MULTI_APP_ALL_GOOD_TAR), err
-            )
+            overall_result += err
 
-            # Create tar bundle with 4 good apps and one that cannot run.
-            err, output, error = execute_helper.execute_command(
-                [
-                    "tar",
-                    "-cf",
-                    "{}/{}".format(
-                        host_tutorials_dir, MULTI_APP_ONE_FAIL_RUN_TAR
-                    ),
-                    "sample-app-1-good_1.0_any.ipk",
-                    "sample-app-2-good_1.0_any.ipk",
-                    "sample-app-3-good_1.0_any.ipk",
-                    "{}_1.1_any.ipk".format(BAD_RUNTIME_IMAGE),
-                    "sample-app-5-good_1.0_any.ipk",
-                ]
-            )
-            overall_err += self._print_result(
-                "tar-{}".format(MULTI_APP_ONE_FAIL_RUN_TAR), err
-            )
+        print("Create Bad Architecture App")
+        self._replace_line_in_file(
+            "src_opkg/CONTROL/control", "Package:", BAD_ARCHITECTURE_IMAGE
+        )
+        self._replace_line_in_file(
+            "src_opkg/CONTROL/control", "Version:", "1.1"
+        )
+        self._replace_line_in_file(
+            "src_opkg/CONTROL/control", "Architecture:", "invalid-architecture"
+        )
 
-            # Create tar bundle with 4 good apps and one that cannot install.
-            err, output, error = execute_helper.execute_command(
-                [
-                    "tar",
-                    "-cf",
-                    "{}/{}".format(
-                        host_tutorials_dir, MULTI_APP_ONE_FAIL_INSTALL_TAR
-                    ),
-                    "sample-app-1-good_1.0_any.ipk",
-                    "sample-app-2-good_1.0_any.ipk",
-                    "{}_1.1_invalid-architecture.ipk".format(
-                        BAD_ARCHITECTURE_IMAGE
-                    ),
-                    "sample-app-4-good_1.0_any.ipk",
-                    "sample-app-5-good_1.0_any.ipk",
-                ]
-            )
-            overall_err += self._print_result(
-                "tar-{}".format(MULTI_APP_ONE_FAIL_INSTALL_TAR), err
-            )
+        err, output, error = execute_helper.execute_command(
+            [
+                "./build-{}".format(TestBuildTestImages.arm_arch),
+                "make",
+                "release",
+            ]
+        )
+        overall_result += err
 
-            if overall_err != 0:
-                assert False
-            else:
-                assert True
+        print("Create Bad OCI Runtime App")
+        self._replace_line_in_file(
+            "src_opkg/CONTROL/control", "Package:", BAD_RUNTIME_IMAGE
+        )
+        self._replace_line_in_file(
+            "src_opkg/CONTROL/control", "Architecture:", "any"
+        )
+        self._remove_first_line_from_file("src_bundle/config.json")
+
+        err, output, error = execute_helper.execute_command(
+            [
+                "./build-{}".format(TestBuildTestImages.arm_arch),
+                "make",
+                "release",
+            ]
+        )
+        overall_result += err
+
+        assert overall_result == 0
+
+    def test_create_tarfiles(
+        self, execute_helper, host_tutorials_dir, payload_version
+    ):
+        """Create the output artifacts."""
+        overall_result = 0
+
+        # Navigate to the location of the IPK
+        os.chdir("release/ipk/")
+
+        # Create tar bundles
+        if not os.path.exists(host_tutorials_dir):
+            os.makedirs(host_tutorials_dir)
+
+        # Create payload_version file
+        with open("payload_format_version", "w") as file:
+            file.write(payload_version)
+
+        print("Copying user-sample-app-package_1.0_any.ipk")
+
+        # User Sample App is needed in both ipk and tar format
+        err, output, error = execute_helper.execute_command(
+            [
+                "cp",
+                "user-sample-app-package_1.0_any.ipk",
+                "{}/user-sample-app-package_1.0_any.ipk".format(
+                    host_tutorials_dir
+                ),
+            ]
+        )
+        overall_result += err
+
+        print("Creating {}/{}".format(host_tutorials_dir, USER_SAMPLE_TAR))
+        err, output, error = execute_helper.execute_command(
+            [
+                "tar",
+                "-cvf",
+                "{}/{}".format(host_tutorials_dir, USER_SAMPLE_TAR),
+                "user-sample-app-package_1.0_any.ipk",
+                "payload_format_version",
+            ]
+        )
+        overall_result += err
+
+        # Create tar bundle with 5 good apps.
+        print(
+            "Creating {}/{}".format(host_tutorials_dir, MULTI_APP_ALL_GOOD_TAR)
+        )
+        err, output, error = execute_helper.execute_command(
+            [
+                "tar",
+                "-cf",
+                "{}/{}".format(host_tutorials_dir, MULTI_APP_ALL_GOOD_TAR),
+                "sample-app-1-good_1.0_any.ipk",
+                "sample-app-2-good_1.0_any.ipk",
+                "sample-app-3-good_1.0_any.ipk",
+                "sample-app-4-good_1.0_any.ipk",
+                "sample-app-5-good_1.0_any.ipk",
+                "payload_format_version",
+            ]
+        )
+        overall_result += err
+
+        # Create tar bundle with 4 good apps and one that cannot run.
+        print(
+            "Creating {}/{}".format(
+                host_tutorials_dir, MULTI_APP_ONE_FAIL_RUN_TAR
+            )
+        )
+
+        err, output, error = execute_helper.execute_command(
+            [
+                "tar",
+                "-cf",
+                "{}/{}".format(host_tutorials_dir, MULTI_APP_ONE_FAIL_RUN_TAR),
+                "sample-app-1-good_1.0_any.ipk",
+                "sample-app-2-good_1.0_any.ipk",
+                "sample-app-3-good_1.0_any.ipk",
+                "{}_1.1_any.ipk".format(BAD_RUNTIME_IMAGE),
+                "sample-app-5-good_1.0_any.ipk",
+                "payload_format_version",
+            ]
+        )
+        overall_result += err
+
+        # Create tar bundle with 4 good apps and one that cannot install.
+        print(
+            "Creating {}/{}".format(
+                host_tutorials_dir, MULTI_APP_ONE_FAIL_INSTALL_TAR
+            )
+        )
+        err, output, error = execute_helper.execute_command(
+            [
+                "tar",
+                "-cf",
+                "{}/{}".format(
+                    host_tutorials_dir, MULTI_APP_ONE_FAIL_INSTALL_TAR
+                ),
+                "sample-app-1-good_1.0_any.ipk",
+                "sample-app-2-good_1.0_any.ipk",
+                "{}_1.1_invalid-architecture.ipk".format(
+                    BAD_ARCHITECTURE_IMAGE
+                ),
+                "sample-app-4-good_1.0_any.ipk",
+                "sample-app-5-good_1.0_any.ipk",
+                "payload_format_version",
+            ]
+        )
+        overall_result += err
+
+        assert overall_result == 0

--- a/ci/lava/tests/test-core-component.py
+++ b/ci/lava/tests/test-core-component.py
@@ -27,6 +27,8 @@ dut_app_home = "/home"
 class TestCoreComponentDUT:
     """Class to encapsulate the testing of core components on a DUT."""
 
+    local_conf_file = None
+
     def test_setup(
         self,
         dut_addr,
@@ -36,14 +38,15 @@ class TestCoreComponentDUT:
         local_conf_file,
     ):
         """Copy the test specific parts, generating items as required."""
-        execute_helper.send_mbl_cli_command(
-            [
-                "put",
-                local_conf_file,
-                os.path.join("/tmp", os.path.basename(local_conf_file)),
-            ],
+        # Copy the local.conf file, creating the directory first.
+        return_code, output, error = execute_helper.send_mbl_cli_command(
+            ["shell", "mkdir -p {}".format(os.path.dirname(local_conf_file))],
             dut_addr,
         )
+        execute_helper.send_mbl_cli_command(
+            ["put", local_conf_file, local_conf_file], dut_addr
+        )
+        TestCoreComponentDUT.local_conf_file = local_conf_file
 
         """Copy the test specific parts, generating items as required."""
         execute_helper.send_mbl_cli_command(
@@ -138,8 +141,12 @@ class TestCoreComponentDUT:
                 "{}/bin/pytest "
                 "--verbose "
                 "--ignore={}/mbl-core/ci --color=no "
-                "{}/mbl-core".format(
-                    venv, dut_tutorials_dir, dut_tutorials_dir
+                "{}/mbl-core "
+                "--local-conf-file {}".format(
+                    venv,
+                    dut_tutorials_dir,
+                    dut_tutorials_dir,
+                    TestCoreComponentDUT.local_conf_file,
                 ),
             ],
             dut_addr,

--- a/ci/lava/tests/test-core-component.py
+++ b/ci/lava/tests/test-core-component.py
@@ -33,14 +33,14 @@ class TestCoreComponentDUT:
         execute_helper,
         host_tutorials_dir,
         dut_tutorials_dir,
-        local_conf_url,
+        local_conf_file,
     ):
         """Copy the test specific parts, generating items as required."""
         execute_helper.send_mbl_cli_command(
             [
                 "put",
-                local_conf_url,
-                os.path.join("/tmp", os.path.basename(local_conf_url)),
+                local_conf_file,
+                os.path.join("/tmp", os.path.basename(local_conf_file)),
             ],
             dut_addr,
         )

--- a/ci/lava/tests/test-core-component.py
+++ b/ci/lava/tests/test-core-component.py
@@ -14,6 +14,7 @@ The test_component function runs pytest on the DUT via the mbl-cli on the
 mbl-core copy.
 
 """
+import os
 import pytest
 import re
 import subprocess
@@ -23,12 +24,27 @@ import subprocess
 dut_app_home = "/home"
 
 
-class Test_Core_Component_DUT:
+class TestCoreComponentDUT:
     """Class to encapsulate the testing of core components on a DUT."""
 
     def test_setup(
-        self, dut_addr, execute_helper, host_tutorials_dir, dut_tutorials_dir
+        self,
+        dut_addr,
+        execute_helper,
+        host_tutorials_dir,
+        dut_tutorials_dir,
+        local_conf_url,
     ):
+        """Copy the test specific parts, generating items as required."""
+        execute_helper.send_mbl_cli_command(
+            [
+                "put",
+                local_conf_url,
+                os.path.join("/tmp", os.path.basename(local_conf_url)),
+            ],
+            dut_addr,
+        )
+
         """Copy the test specific parts, generating items as required."""
         execute_helper.send_mbl_cli_command(
             [

--- a/ci/lava/tests/test-systemd.py
+++ b/ci/lava/tests/test-systemd.py
@@ -10,14 +10,14 @@ import re
 import subprocess
 
 
-class Test_Systemd:
+class TestSystemd:
     """Class to encapsulate the testing of systemd on a DUT."""
 
     dut_address = ""
 
     def test_setup_dut_addr(self, dut_addr):
         """Store the device address."""
-        Test_Systemd.dut_address = dut_addr
+        TestSystemd.dut_address = dut_addr
 
         assert dut_addr != ""
 
@@ -26,12 +26,12 @@ class Test_Systemd:
         # Check status
         err, stdout, stderr = execute_helper.send_mbl_cli_command(
             ["shell", "systemctl --no-pager is-system-running"],
-            Test_Systemd.dut_address,
+            TestSystemd.dut_address,
         )
         if err != 0:
             suberr, stdout, stderr = execute_helper.send_mbl_cli_command(
                 ["shell", "systemctl --no-pager --failed"],
-                Test_Systemd.dut_address,
+                TestSystemd.dut_address,
             )
             print(stdout)
         assert err == 0
@@ -63,6 +63,6 @@ class Test_Systemd:
         # Check status
         err, stdout, stderr = execute_helper.send_mbl_cli_command(
             ["shell", "systemctl --no-pager status {}".format(test_action)],
-            Test_Systemd.dut_address,
+            TestSystemd.dut_address,
         )
         assert err == 0


### PR DESCRIPTION
Updated conftest.py to have a method of downloading files from URLs as
part of a fixture.
Updated conftest.py to control the debug output of execute_command using
the --debug_output option.
Updated core-component tests to allow the passing through of the
local.conf file.
Updated test-build-tutorial-images.py to have the steps as separate
tests instead of a single large function.
Tidied class names by removing underscores.