### PR TITLE
Fix the partitions test.

### DIFF
--- a/ci/lava/tests/test-core-component.py
+++ b/ci/lava/tests/test-core-component.py
@@ -119,10 +119,11 @@ class Test_Core_Component_DUT:
         return_code, output, error = execute_helper.send_mbl_cli_command(
             [
                 "shell",
+                'su -l -c "'
                 "{}/bin/pytest "
                 "--verbose "
                 "--ignore={}/mbl-core/ci --color=no "
-                "{}/mbl-core".format(
+                '{}/mbl-core"'.format(
                     venv, dut_tutorials_dir, dut_tutorials_dir
                 ),
             ],

--- a/ci/lava/tests/test-core-component.py
+++ b/ci/lava/tests/test-core-component.py
@@ -119,7 +119,7 @@ class Test_Core_Component_DUT:
         return_code, output, error = execute_helper.send_mbl_cli_command(
             [
                 "shell",
-                'su -l -c "'
+                'sh -l -c "'
                 "{}/bin/pytest "
                 "--verbose "
                 "--ignore={}/mbl-core/ci --color=no "


### PR DESCRIPTION
Change the shell command for the pytest running on the DUT to a proper login shell. This corrects path issues in the tests.