### PR TITLE
firmware-management: Add mbl-watchdog-init utility

### DIFF
--- a/firmware-management/mbl-watchdog-init/CMakeLists.txt
+++ b/firmware-management/mbl-watchdog-init/CMakeLists.txt
@@ -9,3 +9,5 @@ add_executable(mbl-watchdog-init ${MBL_WATCHDOG_INIT_SRC})
 target_compile_options(mbl-watchdog-init
     PUBLIC -Wall -Wextra -Wpedantic -Werror -Wshadow -Wcast-align -Wwrite-strings -Wunreachable-code
 )
+
+install(TARGETS mbl-watchdog-init DESTINATION bin)

--- a/firmware-management/mbl-watchdog-init/CMakeLists.txt
+++ b/firmware-management/mbl-watchdog-init/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(mblWatchdogInit)
+
+set(MBL_WATCHDOG_INIT_SRC "${CMAKE_CURRENT_SOURCE_DIR}/mbl-watchdog-init.c")
+
+add_executable(mbl-watchdog-init ${MBL_WATCHDOG_INIT_SRC})
+
+target_compile_options(mbl-watchdog-init 
+    PUBLIC -Wall -Wpedantic -Werror
+)

--- a/firmware-management/mbl-watchdog-init/CMakeLists.txt
+++ b/firmware-management/mbl-watchdog-init/CMakeLists.txt
@@ -6,6 +6,6 @@ set(MBL_WATCHDOG_INIT_SRC "${CMAKE_CURRENT_SOURCE_DIR}/mbl-watchdog-init.c")
 
 add_executable(mbl-watchdog-init ${MBL_WATCHDOG_INIT_SRC})
 
-target_compile_options(mbl-watchdog-init 
-    PUBLIC -Wall -Wpedantic -Werror
+target_compile_options(mbl-watchdog-init
+    PUBLIC -Wall -Wextra -Wpedantic -Werror -Wshadow -Wcast-align -Wwrite-strings -Wunreachable-code
 )

--- a/firmware-management/mbl-watchdog-init/mbl-watchdog-init.c
+++ b/firmware-management/mbl-watchdog-init/mbl-watchdog-init.c
@@ -75,10 +75,25 @@ int print_last_boot_reason(const int boot_status)
     switch (boot_status)
     {
         case WDIOF_OVERHEAT:
-            log_info("The last reboot was caused by the CPU overheating.\n");
+            log_info("The last reboot was caused by the CPU overheating.");
             return 0;
         case WDIOF_CARDRESET:
-            log_info("The last reboot was caused by a watchdog reset.\n");
+            log_info("The last reboot was caused by a watchdog reset.");
+            return 0;
+        case WDIOF_FANFAULT:
+            log_info("The last reboot was because a system fan monitored by the watchdog card failed.");
+            return 0;
+        case WDIOF_EXTERN1:
+            log_info("The last reboot was because external monitoring relay/source 1 was triggered.");
+            return 0;
+        case WDIOF_EXTERN2:
+            log_info("The last reboot was because external monitoring relay/source 2 was triggered.");
+            return 0;
+        case WDIOF_POWERUNDER:
+            log_info("The last reboot was due to the machine showing an undervoltage status.");
+            return 0;
+        case WDIOF_POWEROVER:
+            log_info("The last reboot was due to the machine showing an overvoltage status.");
             return 0;
     }
     return -1;

--- a/firmware-management/mbl-watchdog-init/mbl-watchdog-init.c
+++ b/firmware-management/mbl-watchdog-init/mbl-watchdog-init.c
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2019 Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ *
+ * This utility initialises the hardware watchdog and sets the timeout.
+ * The program also tries to determine the last boot reason so we can tell if
+ * the last reboot was caused by the hardware watchdog.
+ * This code is intended for use with our robust update mechanism; we need
+ * to start the watchdog before we mount the rootfs, so the device reboots if
+ * loading the rootfs fails.
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <getopt.h>
+#include <linux/watchdog.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+//============================================================================
+// Error handling convenience functions
+int is_err(const int ret)
+{
+    return ret == -1;
+}
+
+
+int handle_errno(const char *message)
+{
+    int err_code = errno;
+    perror(message);
+    return err_code;
+}
+
+//============================================================================
+// Watchdog functions
+int set_watchdog_timeout(const int watchdog_fd, int *timeout)
+{
+    return ioctl(watchdog_fd, WDIOC_SETTIMEOUT, timeout);
+}
+
+
+int get_last_boot_status(const int watchdog_fd, int *flags)
+{
+    return ioctl(watchdog_fd, WDIOC_GETBOOTSTATUS, flags);
+}
+
+
+int print_last_boot_reason(const int boot_status)
+{
+    switch (boot_status)
+    {
+        case WDIOF_OVERHEAT:
+            printf("The last reboot was caused by the CPU overheating.\n");
+            return 0;
+        case WDIOF_CARDRESET:
+            printf("The last reboot was caused by a watchdog reset.\n");
+            return 0;
+    }
+    return -1;
+}
+
+//============================================================================
+// Main entry point
+int main(int argc, char **argv)
+{
+    int timeout = 0;
+    char* wdog_filename = "";
+
+    // Parse command line arguments
+    int current_opt;
+    int optindex;
+    struct option longopts[] = {
+        {"timeout", required_argument, NULL, 't'},
+        {"wdog-fname", required_argument, NULL, 'w'},
+    };
+
+    while ((current_opt = getopt_long(argc, argv, "tw:", longopts, &optindex)) != -1)
+    {
+        switch (current_opt)
+        {
+            case 't':
+                timeout = atoi(optarg);
+                break;
+            case 'w':
+                wdog_filename = optarg;
+                break;
+            default:
+                printf("--timeout and --wdog-fname must be provided. Exiting.\n");
+                return EXIT_FAILURE;
+        }
+    }
+
+    const int wdog_fd = open(wdog_filename, O_WRONLY);
+    if (is_err(wdog_fd))
+    {
+        return handle_errno("Failed to open watchdog device file");
+    }
+
+    int flags;
+    const int gs_ret = get_last_boot_status(wdog_fd, &flags);
+    if (is_err(gs_ret))
+    {
+        perror("Failed to get the last boot status");
+    }
+    else
+    {
+        const int lb_ret = print_last_boot_reason(flags);
+        if (is_err(lb_ret))
+        {
+            printf("Failed to determine last boot reason.\n");
+        }
+    }
+
+    const int to_ret = set_watchdog_timeout(wdog_fd, &timeout);
+    if (is_err(to_ret))
+    {
+        return handle_errno("Failed to set the watchdog timeout");
+    }
+
+    const int cl_ret = close(wdog_fd);
+    if (is_err(cl_ret))
+    {
+        return handle_errno("Failed to close the watchdog device file");
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/firmware-management/mbl-watchdog-init/mbl-watchdog-init.c
+++ b/firmware-management/mbl-watchdog-init/mbl-watchdog-init.c
@@ -120,6 +120,12 @@ int numeric_string_to_positive_int(const char* const str)
     char *endptr;
     const long int res = strtol(str, &endptr, 0);
 
+    if (*endptr != '\0' || endptr == str)
+    {
+        log_error("String must contain digits only.");
+        exit(EXIT_FAILURE);
+    }
+
     if ((errno == ERANGE && (res == LONG_MAX || res == LONG_MIN))
            || (errno != 0 && res == 0))
     {
@@ -130,12 +136,6 @@ int numeric_string_to_positive_int(const char* const str)
     if (res <= 0 || res > INT_MAX)
     {
         log_error("Integer not in valid range. Expecting a positive integer with maximum size INT_MAX");
-        exit(EXIT_FAILURE);
-    }
-
-    if (endptr == str)
-    {
-        log_error("String must contain digits only.");
         exit(EXIT_FAILURE);
     }
 

--- a/firmware-management/mbl-watchdog-init/mbl-watchdog-init.c
+++ b/firmware-management/mbl-watchdog-init/mbl-watchdog-init.c
@@ -96,7 +96,7 @@ int main(int argc, char **argv)
     int optindex;
     struct option longopts[] = {
         {"timeout", required_argument, NULL, 't'},
-        {"wdog-fname", required_argument, NULL, 'w'},
+        {"device", required_argument, NULL, 'w'},
     };
 
     while ((current_opt = getopt_long(argc, argv, "tw:", longopts, &optindex)) != -1)

--- a/firmware-management/mbl-watchdog-init/mbl-watchdog-init.c
+++ b/firmware-management/mbl-watchdog-init/mbl-watchdog-init.c
@@ -53,7 +53,7 @@ void log_warning(const char * const message)
 void log_info(const char * const message)
 {
     static const char * const prefix = "WATCHDOG-INFO:";
-    fprintf(stderr, "%s %s\n", prefix, message);
+    fprintf(stdout, "%s %s\n", prefix, message);
 }
 
 //============================================================================
@@ -66,22 +66,32 @@ int set_watchdog_timeout(const int watchdog_fd, int * const timeout)
 
 void print_last_boot_reason(const int boot_status)
 {
-    switch (boot_status)
+    if (boot_status == 0)
     {
-        case WDIOF_OVERHEAT:
-            log_info("The last reboot was caused by the CPU overheating.");
-        case WDIOF_CARDRESET:
-            log_info("The last reboot was caused by a watchdog reset.");
-        case WDIOF_FANFAULT:
-            log_info("The last reboot was because a system fan monitored by the watchdog card failed.");
-        case WDIOF_EXTERN1:
-            log_info("The last reboot was because external monitoring relay/source 1 was triggered.");
-        case WDIOF_EXTERN2:
-            log_info("The last reboot was because external monitoring relay/source 2 was triggered.");
-        case WDIOF_POWERUNDER:
-            log_info("The last reboot was due to the machine showing an undervoltage status.");
-        case WDIOF_POWEROVER:
-            log_info("The last reboot was due to the machine showing an overvoltage status.");
+        log_info("Normal boot.");
+    }
+    else
+    {
+        if (boot_status & WDIOF_OVERHEAT)
+            log_warning("The last reboot was caused by the CPU overheating.");
+
+        if (boot_status & WDIOF_CARDRESET)
+            log_warning("The last reboot was caused by a watchdog reset.");
+
+        if (boot_status & WDIOF_FANFAULT)
+            log_warning("The last reboot was because a system fan monitored by the watchdog card failed.");
+
+        if (boot_status & WDIOF_EXTERN1)
+            log_warning("The last reboot was because external monitoring relay/source 1 was triggered.");
+
+        if (boot_status & WDIOF_EXTERN2)
+            log_warning("The last reboot was because external monitoring relay/source 2 was triggered.");
+
+        if (boot_status & WDIOF_POWERUNDER)
+            log_warning("The last reboot was due to the machine showing an undervoltage status.");
+
+        if (boot_status & WDIOF_POWEROVER)
+            log_warning("The last reboot was due to the machine showing an overvoltage status.");
     }
 }
 

--- a/firmware-management/mbl-watchdog-init/mbl-watchdog-init.c
+++ b/firmware-management/mbl-watchdog-init/mbl-watchdog-init.c
@@ -120,16 +120,16 @@ int numeric_string_to_positive_int(const char* const str)
     char *endptr;
     const long int res = strtol(str, &endptr, 0);
 
-    if (*endptr != '\0' || endptr == str)
-    {
-        log_error("String must contain digits only.");
-        exit(EXIT_FAILURE);
-    }
-
     if ((errno == ERANGE && (res == LONG_MAX || res == LONG_MIN))
            || (errno != 0 && res == 0))
     {
         log_error("strtol failed");
+        exit(EXIT_FAILURE);
+    }
+
+    if (*endptr != '\0' || endptr == str)
+    {
+        log_error("String must contain digits only.");
         exit(EXIT_FAILURE);
     }
 

--- a/firmware-management/mbl-watchdog-init/mbl-watchdog-init.c
+++ b/firmware-management/mbl-watchdog-init/mbl-watchdog-init.c
@@ -102,7 +102,7 @@ int get_last_boot_status(const int watchdog_fd)
     const int gs_ret = ioctl(watchdog_fd, WDIOC_GETBOOTSTATUS, &flags);
     if (is_err(gs_ret))
     {
-        return -1;
+        return gs_ret;
     }
 
     const int lb_ret = print_last_boot_reason(flags);


### PR DESCRIPTION
For our robust update mechanism we need to initialise and set the
hardware watchdog timeout early in the boot process. This patch adds a
utility which can set the hardware watchdog timeout and query the system
for the last reboot reason.

Jenkins: http://jenkins.mbed-linux.arm.com/job/rw-test/162/

LAVA: http://e120856-lin.cambridge.arm.com/results.php?image_version=custom&image_number=162&custom_version=rw-test&lava_query=&lava_owner=&failures=false&submitter=robwal02&sort=by_job