### PR TITLE
Backport Refactor BSP tests to 0.9

### DIFF
--- a/ci/lava/tests/bsp.yaml
+++ b/ci/lava/tests/bsp.yaml
@@ -1,0 +1,19 @@
+# Copyright (c) 2019, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+metadata:
+    format: Lava-Test Test Definition 1.0
+    name: Systemd
+    description: Run the BSP tests
+
+    parameters:
+        #
+        # virtual_env: specifies the Python virtual environment
+        #
+        virtual_env:
+
+run:
+    steps:
+        - . $virtual_env/bin/activate
+        - pytest --verbose -s ./ci/lava/tests/test-bsp.py

--- a/ci/lava/tests/test-bsp.py
+++ b/ci/lava/tests/test-bsp.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+# Copyright (c) 2019 Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Script to run systemd tests on the DUT."""
+
+import pytest
+import re
+import subprocess
+
+
+class TestBSP:
+    """Class to encapsulate the testing of systemd on a DUT."""
+
+    dut_address = ""
+
+    def test_setup_dut_addr(self, dut_addr):
+        """Store the device address."""
+        TestBSP.dut_address = dut_addr
+
+        assert dut_addr
+
+    def test_badblocks(self, execute_helper):
+        """Perform the test on the DUT via the mbl-cli."""
+        err, stdout, stderr = execute_helper.send_mbl_cli_command(
+            [
+                "shell",
+                'sh -l -c "badblocks -v '
+                "$(/sbin/blkid -L rootfs1 | sed 's/p[0-9]+$//')"
+                '"',
+            ],
+            TestBSP.dut_address,
+        )
+        print(stdout)
+        assert err == 0 and "Pass" in stdout
+
+    def test_memtester(self, execute_helper):
+        """Perform the test on the DUT via the mbl-cli."""
+        err, stdout, stderr = execute_helper.send_mbl_cli_command(
+            [
+                "shell",
+                'sh -l -c "' "memtester  1M 1 | sed 's/:.*ok/: ok/g'" '"',
+            ],
+            TestBSP.dut_address,
+        )
+        print(stdout)
+        assert err == 0
+
+    def test_optee(self, execute_helper):
+        """Perform the test on the DUT via the mbl-cli."""
+        err, stdout, stderr = execute_helper.send_mbl_cli_command(
+            ["shell", 'sh -l -c "' "xtest l 0 -t regression" '"'],
+            TestBSP.dut_address,
+        )
+        print(stdout)
+        assert err == 0


### PR DESCRIPTION
* Refactor BSP tests to work in lxc container.

Changed the BSP tests to run under pytest control. This removes the need
for the linaro repo.