### PR TITLE
Add test_psa-trusted-storage-linux.py for on-target running of test binaries

### DIFF
--- a/mbl-core/tests/libs/psa-trusted-storage-linux/test_psa-trusted-storage-linux.py
+++ b/mbl-core/tests/libs/psa-trusted-storage-linux/test_psa-trusted-storage-linux.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+# Copyright (c) 2019 Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Pytest for testing the psa_trusted_storage_linux library.
+
+The actual tests should already be on the target, this script just runs them.
+"""
+
+import os
+import logging
+import pathlib
+import pytest
+import subprocess
+
+
+TESTS = "/usr/bin/psa-storage-example-app"
+
+
+def test_psa_trusted_storage_linux_tests_exist():
+    """Check that the test binaries are on the target"""
+    assert TESTS
+
+
+@pytest.mark.parametrize("test", TESTS, ids=TESTS)
+def test_psa_trusted_storage_linux(test):
+    """Run a test binary on the target"""
+    result = subprocess.run(
+        [TESTS_PATH / test],
+        check=False,
+        cwd=TESTS_PATH,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        logging.getLogger().error(result.stdout)
+    assert result.returncode == 0


### PR DESCRIPTION
This PR submits a test script for running the psa_trusted_storage_linux test binary.