### PR TITLE
ci:lava:tests: Add image update test.

### DIFF
--- a/ci/lava/conftest.py
+++ b/ci/lava/conftest.py
@@ -92,6 +92,7 @@ def pytest_report_teststatus(report):
         )
         return report.outcome, "*", lava
 
+
 def pytest_generate_tests(metafunc):
     """Select tests that have the update_component_name specified as marker."""
     # This is called for every test. Only get/set command line arguments

--- a/ci/lava/conftest.py
+++ b/ci/lava/conftest.py
@@ -7,11 +7,75 @@
 
 import os
 import pytest
-import re
-import subprocess
-import sys
-import tempfile
-import urllib.request
+
+from helpers import download_from_url, get_dut_address, ExecuteHelper
+
+
+def pytest_addoption(parser):
+    """Add option parsing to pytest."""
+    # Common parameters
+    parser.addoption("--venv", action="store", default="/tmp/venv")
+    parser.addoption("--debug-output", action="store_true")
+    parser.addoption("--device", action="store", default="none")
+    parser.addoption("--dut", action="store", default="auto")
+    parser.addoption(
+        "--dut-download-dir", action="store", default="/tmp/pytest"
+    )
+    parser.addoption(
+        "--host-download-dir", action="store", default="/tmp/pytest"
+    )
+
+    # Tutorial tests parameters
+    parser.addoption("--dut-tutorials-dir", action="store", default="/scratch")
+    parser.addoption(
+        "--host-tutorials-dir", action="store", default="/tmp/tutorials"
+    )
+    parser.addoption("--payload-version", action="store", default="1")
+
+    # local.conf tests parameters
+    parser.addoption("--local-conf-file", action="store", default="")
+
+    # Boot component update test parameters
+    parser.addoption(
+        "--update-component-name",
+        action="store",
+        choices=["bootloader1", "bootloader2", "kernel", "rootfs"],
+    )
+    parser.addoption("--update-payload-url", action="store")
+    parser.addoption("--update-payload-testinfo-url", action="store")
+    parser.addoption(
+        "--update-method",
+        action="store",
+        default="mbl-cli",
+        choices=["pelion", "mbl-cli"],
+    )
+
+
+def pytest_configure(config):
+    """Register custom markers."""
+    config.addinivalue_line(
+        "markers",
+        "pelion: mark a test to be run when the update method is pelion",
+    )
+    config.addinivalue_line(
+        "markers",
+        "mbl_cli: mark a test to be run when the update method is mbl-cli",
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    """Select tests depending the update-method passed as argument."""
+    update_method = config.getoption("--update-method")
+    skip = pytest.mark.skip(
+        reason="update-method {} selected".format(update_method)
+    )
+    for item in items:
+        markers = set(m.name for m in item.iter_markers())
+        # We skip tests which don't match the update_method
+        # mbl-cli is replaced with mbl_cli
+        if markers and update_method.replace("-", "_") not in markers:
+            print(item)
+            item.add_marker(skip)
 
 
 def pytest_report_teststatus(report):
@@ -22,70 +86,29 @@ def pytest_report_teststatus(report):
                 report.nodeid.replace(" ", "_")
             )
             return report.outcome, "*", lava
-
     if report.failed:
         lava = "<LAVA_SIGNAL_TESTCASE TEST_CASE_ID={} RESULT=fail>".format(
             report.nodeid.replace(" ", "_")
         )
         return report.outcome, "*", lava
 
-
-def pytest_addoption(parser):
-    """Add option parsing to pytest."""
-    parser.addoption("--debug-output", action="store_true")
-    parser.addoption("--device", action="store", default="none")
-    parser.addoption("--dut", action="store", default="auto")
-    parser.addoption(
-        "--dut-download-dir", action="store", default="/tmp/pytest"
-    )
-    parser.addoption("--dut-tutorials-dir", action="store", default="/scratch")
-    parser.addoption(
-        "--host-download-dir", action="store", default="/tmp/pytest"
-    )
-    parser.addoption(
-        "--host-tutorials-dir", action="store", default="/tmp/tutorials"
-    )
-    parser.addoption("--local-conf-file", action="store", default="")
-    parser.addoption("--payload-version", action="store", default="1")
-    parser.addoption("--venv", action="store", default="/tmp/venv")
+def pytest_generate_tests(metafunc):
+    """Select tests that have the update_component_name specified as marker."""
+    # This is called for every test. Only get/set command line arguments
+    # if the argument is specified in the list of test "fixturenames".
+    option_value = metafunc.config.option.update_component_name
+    if (
+        "update_component_name" in metafunc.fixturenames
+        and option_value is not None
+    ):
+        metafunc.parametrize("update_component_name", [option_value])
 
 
-def _download_from_url(url):
-
-    filename = None
-
-    if url:
-
-        filename = os.path.join(tempfile.mkdtemp(), os.path.basename(url))
-
-        try:
-            urllib.request.urlretrieve(url, filename)
-        except Exception as inst:
-            print("\n\nError {}\n\n".format(type(inst)))
-            print(
-                "urlretrieve failed. Trying alternative method by adding "
-                "mapping between 192.168.130.43 and "
-                "artifactory-proxy.mbed-linux.arm.com into /etc/hosts."
-            )
-
-            try:
-                f = open("/etc/hosts", "a")
-                f.write(
-                    "192.168.130.43  artifactory-proxy.mbed-linux.arm.com\n"
-                )
-            except Exception as inst:
-                print("\n\nError {}\n\n".format(type(inst)))
-                print("Could not update /etc/hosts. Perhaps run as root?")
-
-            # re-try the urlretrieve.
-            try:
-                urllib.request.urlretrieve(url, filename)
-            except Exception as inst:
-                print("\n\nError {}\n\n".format(type(inst)))
-                print("\n\nAlternative method also failed.\n\n")
-                filename = None
-
-    return filename
+# common fixtures
+@pytest.fixture
+def venv(request):
+    """Fixture for --venv."""
+    return request.config.getoption("--venv")
 
 
 @pytest.fixture
@@ -113,15 +136,16 @@ def dut_download_dir(request):
 
 
 @pytest.fixture
-def dut_tutorials_dir(request):
-    """Fixture for --dut-tutorials-dir."""
-    return request.config.getoption("--dut-tutorials-dir")
-
-
-@pytest.fixture
 def host_download_dir(request):
     """Fixture for --host-download-dir."""
     return request.config.getoption("--host-download-dir")
+
+
+# Tutorials fixtures
+@pytest.fixture
+def dut_tutorials_dir(request):
+    """Fixture for --dut-tutorials-dir."""
+    return request.config.getoption("--dut-tutorials-dir")
 
 
 @pytest.fixture
@@ -130,6 +154,13 @@ def host_tutorials_dir(request):
     return request.config.getoption("--host-tutorials-dir")
 
 
+@pytest.fixture
+def payload_version(request):
+    """Fixture for --payload-version."""
+    return request.config.getoption("--payload-version")
+
+
+# local.conf fixtures
 @pytest.fixture
 def local_conf_file(request):
     """
@@ -141,96 +172,45 @@ def local_conf_file(request):
     Else return None
     """
     if request.config.getoption("--local-conf-file").startswith("http"):
-        return _download_from_url(
-            request.config.getoption("--local-conf-file")
-        )
+        return download_from_url(request.config.getoption("--local-conf-file"))
     elif os.path.exists(request.config.getoption("--local-conf-file")):
         return request.config.getoption("--local-conf-file")
     else:
         return None
 
 
+# Component update fixtures
 @pytest.fixture
-def payload_version(request):
-    """Fixture for --payload-version."""
-    return request.config.getoption("--payload-version")
+def update_component_name(request):
+    """Fixture for --update-component-name."""
+    return request.config.getoption("--update-component-name")
 
 
 @pytest.fixture
-def venv(request):
-    """Fixture for --venv."""
-    return request.config.getoption("--venv")
+def update_payload(request):
+    """Fixture for --update-payload-url."""
+    return download_from_url(request.config.getoption("--update-payload-url"))
 
 
-class ExecuteHelper:
-    """Class to provide a wrapper for executing commands as a subprocess."""
+@pytest.fixture
+def update_payload_testinfo(request):
+    """
+    Fixture for --update-payload-testinfo-url.
 
-    debug = False
-
-    def __init__(self, request):
-        """Initialise the class."""
-        ExecuteHelper.debug = request.config.getoption("--debug-output")
-
-    @staticmethod
-    def _print(data):
-        # method provided for debug support. Ordinarily this does nothing.
-        # Uncomment the following line to get debug output.
-        if ExecuteHelper.debug:
-            print(data)
-
-    @staticmethod
-    def execute_command(command, timeout=None):
-        """Execute the provided command list.
-
-        Executes the command and returns the error code, stdout and stderr.
-        """
-        ExecuteHelper._print("execute_command start:")
-        ExecuteHelper._print("command:")
-        ExecuteHelper._print(command)
-        p = subprocess.Popen(
-            command,
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            bufsize=-1,
-            universal_newlines=True,
-        )
-        try:
-            output, error = p.communicate(timeout=timeout)
-        except subprocess.TimeoutExpired:
-            ExecuteHelper._print("Timeout after {}".format(timeout))
-            p.kill()
-            output, error = p.communicate()
-
-        ExecuteHelper._print("output:")
-        ExecuteHelper._print(output)
-        ExecuteHelper._print("error:")
-        ExecuteHelper._print(error)
-        ExecuteHelper._print("returnCode:")
-        ExecuteHelper._print(p.returncode)
-        ExecuteHelper._print("execute_command done.")
-
-        return p.returncode, output, error
-
-    @staticmethod
-    def send_mbl_cli_command(command, addr):
-        """Execute the provided mbl-cli command.
-
-        Executes the mbl-cli command and returns the error code, stdout and
-        stderr.
-        """
-        err = 1
-        output = ""
-        error = ""
-
-        if addr != "":
-            cli_command = ["mbl-cli", "--address", addr]
-            for item in command:
-                cli_command.append(item)
-            err, output, error = ExecuteHelper.execute_command(cli_command)
-        return err, output, error
+    Returns the testinfo data as a dictionary
+    """
+    return download_from_url(
+        request.config.getoption("--update-payload-testinfo-url")
+    )
 
 
+@pytest.fixture
+def update_method(request):
+    """Fixture for --update-method."""
+    return request.config.getoption("--update-method")
+
+
+# DUT fixtures
 @pytest.fixture
 def execute_helper(request):
     """Fixture to return the helper class."""
@@ -239,43 +219,5 @@ def execute_helper(request):
 
 @pytest.fixture
 def dut_addr(dut, execute_helper):
-    """Fixture to calculate the DUT IP address."""
-    dut_addr = ""
-
-    return_code, list_output, error = execute_helper.execute_command(
-        ["mbl-cli", "list"]
-    )
-
-    # The default value for dut is set to auto. This means use the first
-    # device returned by the mbl-cli. In the test farm set up there is a
-    # one-to-one mapping of device to container, so this is sufficient.
-    # However, allowing a dut to be specified allows manual testing when
-    # there is more than one device detectable on the network.
-    #
-    # The mbl-cli list command returns data in the following format:
-    #     Discovering devices. This will take up to 30 seconds.
-    #     1: mbed-linux-os-2075: fe80::21f:7bff:fe86:a738%enp0s31f6
-    #     2: mbed-linux-os-158: fe80::ecfb:3fff:fece:9376%enp0s20f0u14u1
-    #
-    # The regular expressions below extract the IP address and interface
-    # name as that is used to communicate to the DUT.
-
-    if dut == "auto":
-        # Take the first found device and use that
-        pattern = re.compile(r"\s*1:[^:]+:\s+(?P<address>\S+)")
-        for line in list_output.splitlines():
-            match = pattern.match(line)
-            if match:
-                dut_addr = match.group("address")
-                break
-    else:
-        # Match a device against the provided dut parameter
-        pattern = re.compile(r"\s*.:[^:]+:\s+(?P<address>\S+)")
-        for line in list_output.splitlines():
-            if dut in line:
-                match = pattern.match(line)
-                if match:
-                    dut_addr = match.group("address")
-                    break
-
-    return dut_addr
+    """Fixture to return the DUT address."""
+    return get_dut_address(dut, execute_helper)

--- a/ci/lava/helpers.py
+++ b/ci/lava/helpers.py
@@ -212,7 +212,7 @@ def get_file_contents_md5(path, dut_addr, execute_helper):
 def get_file_sha256sum(path, dut_addr, execute_helper):
     """Run sha256sum on a file on the DUT."""
     exit_code, output, error = execute_helper.send_mbl_cli_command(
-        ["shell", 'su -l -c "sha256sum {}"'.format(path)],
+        ["shell", 'sh -l -c "sha256sum {}"'.format(path)],
         dut_addr,
         raise_on_error=True,
     )

--- a/ci/lava/helpers.py
+++ b/ci/lava/helpers.py
@@ -51,9 +51,7 @@ def read_partition_to_file(
     :param component_size int: (optional) number of bytes to read from disk.
     """
     part_info = Path("/config/factory/part-info")
-    output_file_path = Path("/scratch") / "{}_{}".format(
-        partition_name, stage
-    )
+    output_file_path = Path("/scratch") / "{}_{}".format(partition_name, stage)
     align_file_path = part_info / "MBL_{}_OFFSET_BANK1_KiB".format(
         partition_name.upper()
     )
@@ -93,11 +91,11 @@ def read_partition_to_file(
             ofile=output_file_path,
             align=align_file_path,
             count=count,
-            magnitude=size_magnitude
+            magnitude=size_magnitude,
         )
     )
     execute_helper.send_mbl_cli_command(
-        ["shell", dd_command], dut_addr, raise_on_error=True,
+        ["shell", dd_command], dut_addr, raise_on_error=True
     )
     return output_file_path
 
@@ -124,8 +122,7 @@ def download_from_url(url):
         try:
             with open("/etc/hosts", "a") as f:
                 f.write(
-                    "192.168.130.43  "
-                    "artifactory-proxy.mbed-linux.arm.com\n"
+                    "192.168.130.43  " "artifactory-proxy.mbed-linux.arm.com\n"
                 )
         except PermissionError as inst:
             print("\n\nError {}\n\n".format(type(inst)))
@@ -184,6 +181,7 @@ def get_dut_address(dut, execute_helper):
 
 
 def get_pelion_device_id(dut_addr, execute_helper):
+    """Get the DUT device id by reading the mbl-cloud-client log."""
     _, output, _ = execute_helper.send_mbl_cli_command(
         ["shell", 'grep -i "device id" /var/log/mbl-cloud-client.log'],
         dut_addr,
@@ -202,6 +200,7 @@ def get_kernel_version(dut_addr, execute_helper):
 
 
 def get_file_contents_md5(path, dut_addr, execute_helper):
+    """Run md5sum on a file on the DUT."""
     exit_code, output, error = execute_helper.send_mbl_cli_command(
         ["shell", 'su -l -c "md5sum {}"'.format(path)],
         dut_addr,
@@ -211,6 +210,7 @@ def get_file_contents_md5(path, dut_addr, execute_helper):
 
 
 def get_file_sha256sum(path, dut_addr, execute_helper):
+    """Run sha256sum on a file on the DUT."""
     exit_code, output, error = execute_helper.send_mbl_cli_command(
         ["shell", 'su -l -c "sha256sum {}"'.format(path)],
         dut_addr,
@@ -220,13 +220,11 @@ def get_file_sha256sum(path, dut_addr, execute_helper):
 
 
 def get_mounted_bank_label(mount_point, dut_addr, execute_helper):
+    """Get the mounted partition label at a particular mount."""
     exit_code, output, error = execute_helper.send_mbl_cli_command(
-        [
-            "shell",
-            '/usr/bin/lsblk --noheadings --output "MOUNTPOINT,LABEL"'
-        ],
+        ["shell", '/usr/bin/lsblk --noheadings --output "MOUNTPOINT,LABEL"'],
         dut_addr,
-        raise_on_error=True
+        raise_on_error=True,
     )
     for line in output.split("\n"):
         match = re.search(r"^{} .*".format(mount_point), line)
@@ -239,13 +237,9 @@ def get_mounted_bank_label(mount_point, dut_addr, execute_helper):
 
 
 def get_file_mtime(path, dut_addr, execute_helper):
+    """Get the last modified time of a file on the DUT."""
     exit_code, output, error = execute_helper.send_mbl_cli_command(
-        [
-            "shell",
-            "stat {}".format(path)
-        ],
-        dut_addr,
-        raise_on_error=True,
+        ["shell", "stat {}".format(path)], dut_addr, raise_on_error=True
     )
     for line in output.split("\n"):
         if "Modify:" in line:
@@ -330,10 +324,8 @@ class ExecuteHelper:
                 "Invalid DUT address. Given address is an empty string."
             )
 
-        cli_command = ["mbl-cli", "--address", addr]+[x for x in command]
-        exit_code, output, error = ExecuteHelper.execute_command(
-            cli_command
-        )
+        cli_command = ["mbl-cli", "--address", addr] + [x for x in command]
+        exit_code, output, error = ExecuteHelper.execute_command(cli_command)
         if raise_on_error and exit_code != 0:
             msg = (
                 "mbl-cli command '{cmd}' returned an error code of {code}."
@@ -341,10 +333,7 @@ class ExecuteHelper:
             )
             raise AssertionError(
                 msg.format(
-                    cmd=cli_command,
-                    code=exit_code,
-                    out=output,
-                    err=error
+                    cmd=cli_command, code=exit_code, out=output, err=error
                 )
             )
 

--- a/ci/lava/helpers.py
+++ b/ci/lava/helpers.py
@@ -1,0 +1,351 @@
+#!/usr/bin/env python3
+# Copyright (c) 2019 Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""
+Helpers module.
+
+This module contains helper functions and classes that are used across pytest
+modules.
+"""
+
+import os
+import re
+import subprocess
+import tempfile
+import urllib.request
+from urllib.error import HTTPError
+from pathlib import Path
+
+
+def compare_files(dut_addr, execute_helper, file1, file2):
+    """Run cmp command on files passed as argument using mbl-cli."""
+    cmp_command = "cmp -s {} {}".format(file1, file2)
+    exit_code, output, error = execute_helper.send_mbl_cli_command(
+        ["shell", 'sh -l -c "{}"'.format(cmp_command)], dut_addr
+    )
+    return exit_code
+
+
+def read_partition_to_file(
+    dut_addr, execute_helper, partition_name, stage, component_size=None
+):
+    """Read partition data from the disk on the DUT to a file.
+
+    This function assumes we have a /config/factory/part-info directory on the
+    target, which contains a set of files holding information about the
+    partition offsets and sizes.
+
+    If the component_size is None, we default to reading the entire partition
+    using the offset and size data from the part-info files.
+
+    If component_size is given, we expect the order of magnitude is bytes.
+    We get the offset from the part-info file and read component_size bytes
+    from the disk.
+
+    :param partition_name str: name of the partition, also used to name
+        the extracted file.
+    :param stage str: append a stage to the output file name (e.g 'pre' or
+        'post')
+    :param component_size int: (optional) number of bytes to read from disk.
+    """
+    part_info = Path("/config/factory/part-info")
+    output_file_path = Path("/scratch") / "{}_{}".format(
+        partition_name, stage
+    )
+    align_file_path = part_info / "MBL_{}_OFFSET_BANK1_KiB".format(
+        partition_name.upper()
+    )
+    partition_size_file_path = part_info / "MBL_{}_SIZE_KiB".format(
+        partition_name.upper()
+    )
+    _, partition_size, _ = execute_helper.send_mbl_cli_command(
+        ["shell", "cat {}".format(partition_size_file_path)],
+        dut_addr,
+        raise_on_error=True,
+    )
+    partition_size = partition_size.splitlines()[1]
+    if component_size is None:
+        count = partition_size
+        # set the magnitude to KiB as the size is given in KiB
+        size_magnitude = "K"
+    elif (component_size / 1024) <= int(partition_size):
+        count = component_size
+        # set the magnitude to an empty string as we're reading in 1 byte
+        # blocks.
+        size_magnitude = ""
+    else:
+        raise AssertionError(
+            "Invalid component size, must be <= than the partition size\n"
+            "component_size_KiB={}\npartition_size_KiB={}".format(
+                component_size / 1024, partition_size
+            )
+        )
+    dd_command = (
+        "set -x; "
+        r"BD=$(/sbin/blkid -L rootfs1 | sed 's/p[0-9]\+$//'); "
+        "OF={ofile}; "
+        "SKIP=$(cat {align})K; "
+        "COUNT={count}; "
+        "dd if=$BD of=$OF skip=$SKIP count=$COUNT bs=1{magnitude} "
+        "iflag=skip_bytes".format(
+            ofile=output_file_path,
+            align=align_file_path,
+            count=count,
+            magnitude=size_magnitude
+        )
+    )
+    execute_helper.send_mbl_cli_command(
+        ["shell", dd_command], dut_addr, raise_on_error=True,
+    )
+    return output_file_path
+
+
+def download_from_url(url):
+    """Download a file from the url.
+
+    This method is very specific to our LAVA insfrastructure.
+    If it fails to download the file, it tries to use the proxy set up in Oulu.
+    """
+    if not url:
+        raise AssertionError("url is an empty string")
+
+    filename = os.path.join(tempfile.mkdtemp(), os.path.basename(url))
+    try:
+        urllib.request.urlretrieve(url, filename)
+    except HTTPError as inst:
+        print("\n\nError {}\n\n".format(type(inst)))
+        print(
+            "urlretrieve failed. Trying alternative method by adding "
+            "mapping between 192.168.130.43 and "
+            "artifactory-proxy.mbed-linux.arm.com into /etc/hosts."
+        )
+        try:
+            with open("/etc/hosts", "a") as f:
+                f.write(
+                    "192.168.130.43  "
+                    "artifactory-proxy.mbed-linux.arm.com\n"
+                )
+        except PermissionError as inst:
+            print("\n\nError {}\n\n".format(type(inst)))
+            print("Could not update /etc/hosts. Perhaps run as root?")
+
+        # re-try the urlretrieve.
+        try:
+            urllib.request.urlretrieve(url, filename)
+        except HTTPError as inst:
+            print("\n\nError {}\n\n".format(type(inst)))
+            print("\n\nAlternative method also failed.\n\n")
+            raise
+    return filename
+
+
+def get_dut_address(dut, execute_helper):
+    """Calculate the DUT IP address using mbl-cli."""
+    dut_addr = ""
+
+    exit_code, output, error = execute_helper.execute_command(
+        ["mbl-cli", "list"]
+    )
+
+    # The default value for dut is set to auto. This means use the first
+    # device returned by the mbl-cli. In the test farm set up there is a
+    # one-to-one mapping of device to container, so this is sufficient.
+    # However, allowing a dut to be specified allows manual testing when
+    # there is more than one device detectable on the network.
+    #
+    # The mbl-cli list command returns data in the following format:
+    #     Discovering devices. This will take up to 30 seconds.
+    #     1: mbed-linux-os-2075: fe80::21f:7bff:fe86:a738%enp0s31f6
+    #     2: mbed-linux-os-158: fe80::ecfb:3fff:fece:9376%enp0s20f0u14u1
+    #
+    # The regular expressions below extract the IP address and interface
+    # name as that is used to communicate to the DUT.
+
+    if dut == "auto":
+        # Take the first found device and use that
+        pattern = re.compile(r"\s*1:[^:]+:\s+(?P<address>\S+)")
+        for line in output.splitlines():
+            match = pattern.match(line)
+            if match:
+                dut_addr = match.group("address")
+                break
+    else:
+        # Match a device against the provided dut parameter
+        pattern = re.compile(r"\s*.:[^:]+:\s+(?P<address>\S+)")
+        for line in output.splitlines():
+            if dut in line:
+                match = pattern.match(line)
+                if match:
+                    dut_addr = match.group("address")
+                    break
+    return dut_addr
+
+
+def get_pelion_device_id(dut_addr, execute_helper):
+    _, output, _ = execute_helper.send_mbl_cli_command(
+        ["shell", 'grep -i "device id" /var/log/mbl-cloud-client.log'],
+        dut_addr,
+        raise_on_error=True,
+    )
+
+    return output.split("Device Id: ")[1].splitlines()[0]
+
+
+def get_kernel_version(dut_addr, execute_helper):
+    """Get the kernel version running on the DUT using mbl-cli."""
+    exit_code, output, error = execute_helper.send_mbl_cli_command(
+        ["shell", 'su -l -c "uname -a"'], dut_addr
+    )
+    return exit_code, output
+
+
+def get_file_contents_md5(path, dut_addr, execute_helper):
+    exit_code, output, error = execute_helper.send_mbl_cli_command(
+        ["shell", 'su -l -c "md5sum {}"'.format(path)],
+        dut_addr,
+        raise_on_error=True,
+    )
+    return output.split("\n")[1].split()[0]
+
+
+def get_file_sha256sum(path, dut_addr, execute_helper):
+    exit_code, output, error = execute_helper.send_mbl_cli_command(
+        ["shell", 'su -l -c "sha256sum {}"'.format(path)],
+        dut_addr,
+        raise_on_error=True,
+    )
+    return output.split("\n")[1].split()[0]
+
+
+def get_mounted_bank_label(mount_point, dut_addr, execute_helper):
+    exit_code, output, error = execute_helper.send_mbl_cli_command(
+        [
+            "shell",
+            '/usr/bin/lsblk --noheadings --output "MOUNTPOINT,LABEL"'
+        ],
+        dut_addr,
+        raise_on_error=True
+    )
+    for line in output.split("\n"):
+        match = re.search(r"^{} .*".format(mount_point), line)
+        if match:
+            return match.group(0).split()[1]
+
+    raise AssertionError(
+        "No match for the mount point found! Output was: {}".format(output)
+    )
+
+
+def get_file_mtime(path, dut_addr, execute_helper):
+    exit_code, output, error = execute_helper.send_mbl_cli_command(
+        [
+            "shell",
+            "stat {}".format(path)
+        ],
+        dut_addr,
+        raise_on_error=True,
+    )
+    for line in output.split("\n"):
+        if "Modify:" in line:
+            mtime = line
+            break
+    if not mtime:
+        raise AssertionError(
+            "Could not find Modified Time in the output from `stat`. "
+            "The output was {}".format(output)
+        )
+    return mtime
+
+
+def strings_grep(dut_addr, execute_helper, file_path, pattern):
+    """Run strings command on a file and grep for a pattern using mbl-cli."""
+    command = "strings {} | grep {}".format(file_path, pattern)
+    exit_code, output, error = execute_helper.send_mbl_cli_command(
+        ["shell", 'sh -l -c "{}"'.format(command)],
+        dut_addr,
+        raise_on_error=True,
+    )
+    return output.split("\n")[1]
+
+
+class ExecuteHelper:
+    """Class to provide a wrapper for executing commands as a subprocess."""
+
+    debug = False
+
+    def __init__(self, request):
+        """Initialise the class."""
+        ExecuteHelper.debug = request.config.getoption("--debug-output")
+
+    @staticmethod
+    def _print(data):
+        if ExecuteHelper.debug:
+            print(data)
+
+    @staticmethod
+    def execute_command(command):
+        """Execute the provided command list.
+
+        Executes the command and returns the error code, stdout and stderr.
+        """
+        ExecuteHelper._print("execute_command start:")
+        ExecuteHelper._print("command:")
+        ExecuteHelper._print(command)
+        p = subprocess.Popen(
+            command,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            bufsize=-1,
+            universal_newlines=True,
+        )
+        output, error = p.communicate()
+        ExecuteHelper._print("output:")
+        ExecuteHelper._print(output)
+        ExecuteHelper._print("error:")
+        ExecuteHelper._print(error)
+        ExecuteHelper._print("returnCode:")
+        ExecuteHelper._print(p.returncode)
+        ExecuteHelper._print("execute_command done.")
+
+        return p.returncode, output, error
+
+    @staticmethod
+    def send_mbl_cli_command(command, addr, raise_on_error=False):
+        """Execute the provided mbl-cli command.
+
+        Executes the mbl-cli command and returns the error code, stdout and
+        stderr.
+
+        Optionally raises AssertionError on a non-zero exit code.
+        """
+        exit_code = 1
+        output = ""
+        error = ""
+
+        if not addr:
+            raise AssertionError(
+                "Invalid DUT address. Given address is an empty string."
+            )
+
+        cli_command = ["mbl-cli", "--address", addr]+[x for x in command]
+        exit_code, output, error = ExecuteHelper.execute_command(
+            cli_command
+        )
+        if raise_on_error and exit_code != 0:
+            msg = (
+                "mbl-cli command '{cmd}' returned an error code of {code}."
+                "\nCommand stdout: {out}\nCommand stderr:{err}\n"
+            )
+            raise AssertionError(
+                msg.format(
+                    cmd=cli_command,
+                    code=exit_code,
+                    out=output,
+                    err=error
+                )
+            )
+
+        return exit_code, output, error

--- a/ci/lava/helpers.py
+++ b/ci/lava/helpers.py
@@ -194,7 +194,7 @@ def get_pelion_device_id(dut_addr, execute_helper):
 def get_kernel_version(dut_addr, execute_helper):
     """Get the kernel version running on the DUT using mbl-cli."""
     exit_code, output, error = execute_helper.send_mbl_cli_command(
-        ["shell", 'su -l -c "uname -a"'], dut_addr
+        ["shell", 'sh -l -c "uname -a"'], dut_addr
     )
     return exit_code, output
 

--- a/ci/lava/helpers.py
+++ b/ci/lava/helpers.py
@@ -202,7 +202,7 @@ def get_kernel_version(dut_addr, execute_helper):
 def get_file_contents_md5(path, dut_addr, execute_helper):
     """Run md5sum on a file on the DUT."""
     exit_code, output, error = execute_helper.send_mbl_cli_command(
-        ["shell", 'su -l -c "md5sum {}"'.format(path)],
+        ["shell", 'sh -l -c "md5sum {}"'.format(path)],
         dut_addr,
         raise_on_error=True,
     )

--- a/ci/lava/tests/component-update.yaml
+++ b/ci/lava/tests/component-update.yaml
@@ -1,0 +1,40 @@
+# Copyright (c) 2019, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+metadata:
+    format: Lava-Test Test Definition 1.0
+    name: Boot component update
+    description: Boot component update
+
+parameters:
+    #
+    # virtual_env: specifies the Python virtual environment
+    #
+    virtual_env:
+
+    #
+    # component_name: specifies the bootloader component to update
+    #
+    component_name:
+
+    #
+    # payload_url: specifies the full url of the boot component payload to update
+    #
+    payload_url:
+
+    #
+    # payload_testinfo_url: specifies the full url of the boot component testinfo file
+    #
+    payload_testinfo_url:
+
+    #
+    # update_method: specifies the method used to do the update (mbl-cli or pelion)
+    #
+    update_method:
+
+run:
+    steps:
+        # Activate virtual environment
+        - . $virtual_env/bin/activate
+        - pytest --verbose --debug-output -x -s ./ci/lava/tests/test-component-update.py --update-component-name $component_name --update-payload-url $payload_url --update-payload-testinfo-url $payload_testinfo_url --update-method $update_method

--- a/ci/lava/tests/test-component-update.py
+++ b/ci/lava/tests/test-component-update.py
@@ -207,7 +207,7 @@ class TestComponentUpdate:
 
         # Reboot the device
         execute_helper.send_mbl_cli_command(
-            ["shell", 'su -l -c "reboot || true"'],
+            ["shell", 'sh -l -c "reboot || true"'],
             TestComponentUpdate.dut_address,
         )
 

--- a/ci/lava/tests/test-component-update.py
+++ b/ci/lava/tests/test-component-update.py
@@ -191,7 +191,7 @@ class TestComponentUpdate:
         )
         try:
             _, output, err = execute_helper.send_mbl_cli_command(
-                ["shell", 'su -l -c "{}"'.format(cmd)],
+                ["shell", 'sh -l -c "{}"'.format(cmd)],
                 TestComponentUpdate.dut_address,
                 raise_on_error=True,
             )

--- a/ci/lava/tests/test-component-update.py
+++ b/ci/lava/tests/test-component-update.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+# Copyright (c) 2019 Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""
+Pytest for testing component update.
+
+This module tests the update of image components.
+
+The payload creation script outputs a json file containing information about
+the tests we are going to run. We first gather this information from the
+testinfo file (and the device if the test requires it). After performing the
+update we run some comparisons of the testinfo data gathered before and after
+the update.
+
+The updates can be performed using both the mbl-cli and the pelion device
+management API, the latter is accessed using the manifest-tool.
+The marker "@pytest.mark.pelion" means that the test will be executed only when
+the pelion method is specified on the command line.
+Analogous behaviour with "@pytest.mark.mbl_cli".
+If a test case doesn't have any marker, it will be always executed.
+"""
+
+import json
+import os
+import time
+
+import pytest
+
+from helpers import (
+    read_partition_to_file,
+    get_dut_address,
+    get_file_contents_md5,
+    get_file_sha256sum,
+    get_mounted_bank_label,
+    get_file_mtime,
+    strings_grep,
+    get_pelion_device_id,
+)
+
+
+def _get_testinfo_from_json(filename):
+    if filename is None:
+        raise FileNotFoundError("Failed to find {}".format(filename))
+
+    with open(filename) as fobj:
+        return json.loads(fobj.read())
+
+
+file_cmp_test_info = []
+mounted_bank_test_info = []
+file_timestamp_test_info = []
+part_sha_256_test_info = []
+file_sha256_test_info = []
+
+
+class TestComponentUpdate:
+    """Class to encapsulate the testing of core components on a DUT."""
+
+    update_payload = None
+    dut_address = None
+
+    def test_setup(self, update_payload, dut_addr):
+        """Setup test."""
+        TestComponentUpdate.update_payload = update_payload
+        TestComponentUpdate.dut_address = dut_addr
+        assert TestComponentUpdate.dut_address
+        assert TestComponentUpdate.update_payload
+
+    def test_get_pre_update_testinfo(
+        self, execute_helper, update_payload_testinfo, update_component_name
+    ):
+        """Gather test info from the image before updating it."""
+        expected_test_info = _get_testinfo_from_json(update_payload_testinfo)
+
+        for image_data in expected_test_info["images"]:
+            for item in image_data["tests"]:
+                if item["test_type"] == "file_compare":
+                    file_cmp_test_info.append(
+                        (
+                            image_data["image_name"],
+                            item["args"],
+                            get_file_contents_md5(
+                                **item["args"],
+                                dut_addr=TestComponentUpdate.dut_address,
+                                execute_helper=execute_helper
+                            ),
+                        )
+                    )
+                elif item["test_type"] == "mounted_bank_compare":
+                    mounted_bank_test_info.append(
+                        (
+                            image_data["image_name"],
+                            item["args"],
+                            get_mounted_bank_label(
+                                **item["args"],
+                                dut_addr=TestComponentUpdate.dut_address,
+                                execute_helper=execute_helper
+                            ),
+                        )
+                    )
+                elif item["test_type"] == "file_timestamp_compare":
+                    file_timestamp_test_info.append(
+                        (
+                            image_data["image_name"],
+                            item["args"],
+                            get_file_mtime(
+                                **item["args"],
+                                dut_addr=TestComponentUpdate.dut_address,
+                                execute_helper=execute_helper
+                            ),
+                        )
+                    )
+                elif item["test_type"] == "partition_sha256":
+                    pre_update_img = read_partition_to_file(
+                        TestComponentUpdate.dut_address,
+                        execute_helper,
+                        item["args"]["part_name"],
+                        "pre",
+                        item["args"]["size_B"],
+                    )
+                    pre_timestamp = strings_grep(
+                        TestComponentUpdate.dut_address,
+                        execute_helper,
+                        pre_update_img,
+                        "Built",
+                    )
+                    part_sha_256_test_info.append(
+                        (image_data["image_name"], item["args"], pre_timestamp)
+                    )
+                elif item["test_type"] == "file_sha256":
+                    file_sha256_test_info.append(
+                        (image_data["image_name"], item["args"])
+                    )
+        assert not all(
+            not x
+            for x in [
+                file_cmp_test_info,
+                file_sha256_test_info,
+                part_sha_256_test_info,
+                file_timestamp_test_info,
+                mounted_bank_test_info,
+            ]
+        )
+
+    @pytest.mark.pelion
+    def test_component_update_pelion(
+        self, execute_helper, update_component_name
+    ):
+        """Test update component using Pelion."""
+        # Move to the working directory for the manifest tool.
+        # This directory was where the provisioning test ran
+        # the `manifest-tool init` command.
+        directory = "/tmp/update-resources"
+        os.chdir(directory)
+
+        dev_id = get_pelion_device_id(
+            TestComponentUpdate.dut_address, execute_helper
+        )
+        exit_code, output, err = execute_helper.execute_command(
+            [
+                "manifest-tool",
+                "update",
+                "device",
+                "--device-id",
+                dev_id,
+                "--payload",
+                TestComponentUpdate.update_payload,
+            ]
+        )
+
+        assert exit_code == 0
+
+    @pytest.mark.mbl_cli
+    def test_component_update_mbl_cli(
+        self, execute_helper, update_component_name
+    ):
+        """Test update component using mbl-cli."""
+        # Copy the payload onto the DUT
+        execute_helper.send_mbl_cli_command(
+            ["put", TestComponentUpdate.update_payload, "/scratch/"],
+            TestComponentUpdate.dut_address,
+            raise_on_error=True,
+        )
+
+        # Run the update
+        payload_name = os.path.basename(TestComponentUpdate.update_payload)
+        cmd = "mbl-firmware-update-manager --assume-no /scratch/{}".format(
+            payload_name
+        )
+        try:
+            _, output, err = execute_helper.send_mbl_cli_command(
+                ["shell", 'su -l -c "{}"'.format(cmd)],
+                TestComponentUpdate.dut_address,
+                raise_on_error=True,
+            )
+        except AssertionError:
+            _, output, err = execute_helper.send_mbl_cli_command(
+                ["shell", "cat /var/log/arm_update_activate.log"],
+                TestComponentUpdate.dut_address,
+                raise_on_error=True,
+            )
+            print(output)
+            raise
+        assert "Content of update package installed" in output
+
+        # Reboot the device
+        execute_helper.send_mbl_cli_command(
+            ["shell", 'su -l -c "reboot || true"'],
+            TestComponentUpdate.dut_address,
+        )
+
+    @pytest.mark.mbl_cli
+    def test_dut_online_after_reboot(
+        self, dut, execute_helper, update_component_name
+    ):
+        """Wait for the DUT to be back online after the reboot."""
+        # Wait some time before attempting to discover the DUT
+        time.sleep(30)
+        dut_address = ""
+        num_retries = 0
+        while not dut_address and num_retries < 30:
+            dut_address = get_dut_address(dut, execute_helper)
+            if dut_address:
+                print("DUT {} is online again".format(dut_address))
+            else:
+                print("DUT is still offline. Trying again...")
+            num_retries += 1
+        assert dut_address
+
+    def test_image_post_update_checks(
+        self, execute_helper, update_component_name
+    ):
+        """Run some comparisons against the testinfo data."""
+        if part_sha_256_test_info:
+            self._compare_partition_sha256(execute_helper)
+
+        if file_sha256_test_info:
+            self._compare_file_sha256(execute_helper)
+
+        if file_cmp_test_info:
+            self._compare_files(execute_helper)
+
+        if file_timestamp_test_info:
+            self._compare_file_timestamps(execute_helper)
+
+        if mounted_bank_test_info:
+            self._compare_mounted_bank(execute_helper)
+
+    def _compare_partition_sha256(self, execute_helper):
+        for item in part_sha_256_test_info:
+            img_name, data, before_result = item
+            print("Testing partition sha256 for image {}".format(img_name))
+            post_extracted_img = read_partition_to_file(
+                TestComponentUpdate.dut_address,
+                execute_helper,
+                data["part_name"],
+                "post",
+                data["size_B"],
+            )
+            assert data["sha256"] == get_file_sha256sum(
+                post_extracted_img,
+                TestComponentUpdate.dut_address,
+                execute_helper,
+            )
+            assert (
+                strings_grep(
+                    TestComponentUpdate.dut_address,
+                    execute_helper,
+                    post_extracted_img,
+                    "Built",
+                )
+                != before_result
+            )
+
+    def _compare_file_sha256(self, execute_helper):
+        for item in file_sha256_test_info:
+            img_name, data = item
+            print("Testing file sha256 for image {}".format(img_name))
+            assert data["sha256"] == get_file_sha256sum(
+                data["path"], TestComponentUpdate.dut_address, execute_helper
+            )
+
+    def _compare_files(self, execute_helper):
+        for item in file_cmp_test_info:
+            img_name, data, before_result = item
+            print("Testing file comparison for image {}".format(img_name))
+            assert before_result != get_file_contents_md5(
+                data["path"], TestComponentUpdate.dut_address, execute_helper
+            )
+
+    def _compare_mounted_bank(self, execute_helper):
+        for item in mounted_bank_test_info:
+            img_name, data, before_result = item
+            print("Testing mounted bank for image {}".format(img_name))
+            assert before_result != get_mounted_bank_label(
+                data["mount_point"],
+                TestComponentUpdate.dut_address,
+                execute_helper,
+            )
+
+    def _compare_file_timestamps(self, execute_helper):
+        for item in file_timestamp_test_info:
+            img_name, data, before_result = item
+            print("Testing file timestamps for image {}".format(img_name))
+            assert before_result != get_file_mtime(
+                data["path"], TestComponentUpdate.dut_address, execute_helper
+            )


### PR DESCRIPTION
Add a test to validate image updates using the test info file
generated by our create-update-payload script.

Also add a helpers.py module and move all test helper functions
there. Leave fixtures in conftest.py

NOTE: the rootfs test fails as we're either not rebuilding the rootfs properly in build-update-payloads or the "file_comparison_test" data from the testinfo is wrong, as the rootfs is updated (and the bank is switched) but the mtime of `/etc/build` doesn't change (which is the file the testinfo tells us to check). 