### PR TITLE
Fix pytest configuration to run parametized tests

### DIFF
--- a/ci/lava/conftest.py
+++ b/ci/lava/conftest.py
@@ -46,7 +46,7 @@ def pytest_addoption(parser):
     parser.addoption(
         "--update-method",
         action="store",
-        default="mbl-cli",
+        default="",
         choices=["pelion", "mbl-cli"],
     )
 
@@ -66,6 +66,8 @@ def pytest_configure(config):
 def pytest_collection_modifyitems(config, items):
     """Select tests depending the update-method passed as argument."""
     update_method = config.getoption("--update-method")
+    if not update_method:
+        return
     skip = pytest.mark.skip(
         reason="update-method {} selected".format(update_method)
     )


### PR DESCRIPTION
Only skip update_method test types when update_method command line is set.