### PR TITLE
Update test to not use sfdisk

### DIFF
--- a/ci/lava/tests/test-core-component.py
+++ b/ci/lava/tests/test-core-component.py
@@ -47,6 +47,71 @@ class TestCoreComponentDUT:
         )
         TestCoreComponentDUT.local_conf_file = local_conf_file
 
+        """Copy the test specific parts, generating items as required."""
+        execute_helper.send_mbl_cli_command(
+            [
+                "put",
+                "{}/user-sample-app-package_1.0_any.ipk".format(
+                    host_tutorials_dir
+                ),
+                "{}/app-lifecycle-manager-test-package_1.0_any.ipk".format(
+                    dut_tutorials_dir
+                ),
+            ],
+            dut_addr,
+        )
+
+        execute_helper.send_mbl_cli_command(
+            [
+                "put",
+                "{}/mbl-multi-apps-update-package-all-good.tar".format(
+                    host_tutorials_dir
+                ),
+                dut_tutorials_dir,
+            ],
+            dut_addr,
+        )
+
+        execute_helper.send_mbl_cli_command(
+            [
+                "put",
+                "{}/mbl-multi-apps-update-package-one-fail-run.tar".format(
+                    host_tutorials_dir
+                ),
+                dut_tutorials_dir,
+            ],
+            dut_addr,
+        )
+
+        execute_helper.send_mbl_cli_command(
+            [
+                "put",
+                "{}/mbl-multi-apps-update-package-one-fail-install.tar".format(
+                    host_tutorials_dir
+                ),
+                dut_tutorials_dir,
+            ],
+            dut_addr,
+        )
+
+        # Build the test images
+        execute_helper.execute_command(
+            [
+                "python3",
+                "./firmware-management/mbl-app-manager/tests/native/"
+                "test_case_generator_mbl-app-manager.py",
+                "-o",
+                "{}/app".format(host_tutorials_dir),
+                "-v",
+            ]
+        )
+
+        # Copy the test images to the DUT
+        execute_helper.send_mbl_cli_command(
+            ["put", "-r", "{}/app".format(host_tutorials_dir), dut_app_home],
+            dut_addr,
+        )
+
         # Copy the common parts to the DUT
         execute_helper.send_mbl_cli_command(
             ["put", "-r", "./", "{}/mbl-core".format(dut_tutorials_dir)],
@@ -58,15 +123,6 @@ class TestCoreComponentDUT:
             [
                 "put",
                 "./ci/lava/conftest.py",
-                "{}/mbl-core".format(dut_tutorials_dir),
-            ],
-            dut_addr,
-        )
-
-        execute_helper.send_mbl_cli_command(
-            [
-                "put",
-                "./ci/lava/helpers.py",
                 "{}/mbl-core".format(dut_tutorials_dir),
             ],
             dut_addr,
@@ -85,7 +141,7 @@ class TestCoreComponentDUT:
                 "{}/bin/pytest "
                 "--verbose "
                 "--ignore={}/mbl-core/ci --color=no "
-                "{}/mbl-core/mbl-core/tests/partitions "
+                "{}/mbl-core "
                 '--local-conf-file {}"'.format(
                     venv,
                     dut_tutorials_dir,

--- a/ci/lava/tests/test-core-component.py
+++ b/ci/lava/tests/test-core-component.py
@@ -47,71 +47,6 @@ class TestCoreComponentDUT:
         )
         TestCoreComponentDUT.local_conf_file = local_conf_file
 
-        """Copy the test specific parts, generating items as required."""
-        execute_helper.send_mbl_cli_command(
-            [
-                "put",
-                "{}/user-sample-app-package_1.0_any.ipk".format(
-                    host_tutorials_dir
-                ),
-                "{}/app-lifecycle-manager-test-package_1.0_any.ipk".format(
-                    dut_tutorials_dir
-                ),
-            ],
-            dut_addr,
-        )
-
-        execute_helper.send_mbl_cli_command(
-            [
-                "put",
-                "{}/mbl-multi-apps-update-package-all-good.tar".format(
-                    host_tutorials_dir
-                ),
-                dut_tutorials_dir,
-            ],
-            dut_addr,
-        )
-
-        execute_helper.send_mbl_cli_command(
-            [
-                "put",
-                "{}/mbl-multi-apps-update-package-one-fail-run.tar".format(
-                    host_tutorials_dir
-                ),
-                dut_tutorials_dir,
-            ],
-            dut_addr,
-        )
-
-        execute_helper.send_mbl_cli_command(
-            [
-                "put",
-                "{}/mbl-multi-apps-update-package-one-fail-install.tar".format(
-                    host_tutorials_dir
-                ),
-                dut_tutorials_dir,
-            ],
-            dut_addr,
-        )
-
-        # Build the test images
-        execute_helper.execute_command(
-            [
-                "python3",
-                "./firmware-management/mbl-app-manager/tests/native/"
-                "test_case_generator_mbl-app-manager.py",
-                "-o",
-                "{}/app".format(host_tutorials_dir),
-                "-v",
-            ]
-        )
-
-        # Copy the test images to the DUT
-        execute_helper.send_mbl_cli_command(
-            ["put", "-r", "{}/app".format(host_tutorials_dir), dut_app_home],
-            dut_addr,
-        )
-
         # Copy the common parts to the DUT
         execute_helper.send_mbl_cli_command(
             ["put", "-r", "./", "{}/mbl-core".format(dut_tutorials_dir)],
@@ -123,6 +58,15 @@ class TestCoreComponentDUT:
             [
                 "put",
                 "./ci/lava/conftest.py",
+                "{}/mbl-core".format(dut_tutorials_dir),
+            ],
+            dut_addr,
+        )
+
+        execute_helper.send_mbl_cli_command(
+            [
+                "put",
+                "./ci/lava/helpers.py",
                 "{}/mbl-core".format(dut_tutorials_dir),
             ],
             dut_addr,
@@ -141,7 +85,7 @@ class TestCoreComponentDUT:
                 "{}/bin/pytest "
                 "--verbose "
                 "--ignore={}/mbl-core/ci --color=no "
-                "{}/mbl-core "
+                "{}/mbl-core/mbl-core/tests/partitions "
                 '--local-conf-file {}"'.format(
                     venv,
                     dut_tutorials_dir,

--- a/mbl-core/tests/partitions/test_partitions.py
+++ b/mbl-core/tests/partitions/test_partitions.py
@@ -112,7 +112,7 @@ def get_actual_part_table():
     part_table = []
 
     for f in device_dir.glob("{}p[0-9]*".format(glob.escape(block_device))):
-        size_in_sectors = int((f / "siz").read_text())
+        size_in_sectors = int((f / "size").read_text())
         start_in_sectors = int((f / "start").read_text())
         # Divide the numbers by 2 to convert 512B sectors into KiB
         part_table.append((start_in_sectors // 2, size_in_sectors // 2))

--- a/mbl-core/tests/partitions/test_partitions.py
+++ b/mbl-core/tests/partitions/test_partitions.py
@@ -112,8 +112,8 @@ def get_actual_part_table():
     part_table = []
 
     for f in device_dir.glob("{}p[0-9]*".format(glob.escape(block_device))):
-        size_in_sectors = int(get_var_for_actual_part(f / "size"))
-        start_in_sectors = int(get_var_for_actual_part(f / "start"))
+        size_in_sectors = int((f / "siz").read_text())
+        start_in_sectors = int((f / "start").read_text())
         # Divide the numbers by 2 to convert 512B sectors into KiB
         part_table.append((start_in_sectors // 2, size_in_sectors // 2))
 
@@ -124,21 +124,6 @@ def get_actual_part_table():
     del part_table[3]
 
     return part_table
-
-
-def get_var_for_actual_part(sys_part_info_file):
-    """
-    Get the value of partition information.
-
-    Args:
-    * sys_part_info_file (str): name of file containing the partition
-    information.
-
-    Returns (str): the contents of the config file for the given variable name
-    and partition, or an exception if the config file doesn't exist.
-    """
-    return sys_part_info_file.read_text()
-
 
 
 def test_part_table():

--- a/mbl-core/tests/partitions/test_partitions.py
+++ b/mbl-core/tests/partitions/test_partitions.py
@@ -144,6 +144,5 @@ def get_var_for_actual_part(var_name, part_name, default=None):
     return path.read_text()
 
 
-
 def test_part_table():
     assert get_actual_part_table() == get_expected_part_table()

--- a/mbl-core/tests/partitions/test_partitions.py
+++ b/mbl-core/tests/partitions/test_partitions.py
@@ -8,7 +8,7 @@ Pytest for checking partition offsets and sizes.
 
 The main idea is to create two lists of (offset, size) pairs:
 * one based on partition data left in the factory config partition;
-* one based on the output of "sfdisk -J".
+* one based on the content of /sys/block.
 
 We then check that the two lists are equal.
 """
@@ -16,9 +16,9 @@ We then check that the two lists are equal.
 import pathlib
 import re
 import subprocess
-import json
 
-PART_INFO_DIR = pathlib.Path("/config/factory/part-info")
+EXPECTED_PART_INFO_DIR = pathlib.Path("/config/factory/part-info")
+ACTUAL_PART_INFO_DIR = pathlib.Path("/sys/block")
 
 
 def get_var_for_part(var_name, part_name, default=None):
@@ -35,7 +35,7 @@ def get_var_for_part(var_name, part_name, default=None):
     and partition.
     """
     filename = "MBL_{}_{}".format(re.escape(part_name), re.escape(var_name))
-    path = PART_INFO_DIR / filename
+    path = EXPECTED_PART_INFO_DIR / filename
     if default is not None and not path.is_file():
         return default
     return path.read_text()
@@ -47,7 +47,7 @@ def get_fs_part_names():
     """
     part_names = []
     filename_re = re.compile(r"^MBL_([A-Z0-9_]+)_SIZE_KiB$")
-    for f in PART_INFO_DIR.iterdir():
+    for f in EXPECTED_PART_INFO_DIR.iterdir():
         filename_match = filename_re.match(f.name)
         if filename_match:
             part_name = filename_match.group(1)
@@ -86,9 +86,12 @@ def get_device_file_for_parts():
 
     This function assumes that all of the partitions are on the same device.
     """
-    return subprocess.check_output(["blkid", "-L", "rootfs1"]).rsplit(b"p", 1)[
-        0
-    ]
+    return str(
+        subprocess.check_output(["blkid", "-L", "rootfs1"])
+        .rsplit(b"p", 1)[0]
+        .split(b"/")[2],
+        "utf-8",
+    )
 
 
 def get_actual_part_table():
@@ -96,34 +99,50 @@ def get_actual_part_table():
     Get the actual partition table.
 
     Returns a list of (offset, size) pairs for file system partitions, based on
-    the output of "sfdisk -J".
+    the content of /sys/block.
+
 
     The list is sorted and the offsets and sizes are in KiB units.
     """
     device_file = get_device_file_for_parts()
-    # "sfdisk -J" gives JSON output
-    sfdisk_json = subprocess.check_output(["sfdisk", "-J", device_file])
+    device_dir = pathlib.Path.joinpath(ACTUAL_PART_INFO_DIR, device_file)
 
-    # The output contains some info we're not interested in - we just want the
-    # "partitions" list which contains dicts with an offsets and sizes for each
-    # partition.
-    sfdisk_part_table = json.loads(sfdisk_json)["partitiontable"]["partitions"]
+    part_table = []
 
-    # Convert the partition table from sfdisk into a list of (offset, size)
-    # tuples. Divide the numbers by 2 to convert 512B sectors that sfdisk uses
-    # into KiB
-    part_table = sorted(
-        [
-            (int(d["start"]) // 2, int(d["size"]) // 2)
-            for d in sfdisk_part_table
-        ]
-    )
+    filename_re = re.compile(r"^.*{}p([0-9]+)$".format(device_file))
+
+    for f in device_dir.iterdir():
+        filename_match = filename_re.match(f.name)
+        if filename_match:
+            size_KiB = int(get_var_for_actual_part("size", f))
+            offset1_KiB = int(get_var_for_actual_part("start", f))
+            part_table.append((offset1_KiB // 2, size_KiB // 2))
+
+    part_table = sorted(part_table)
 
     # The fourth partition is an "extended partition" that just contains other
     # partitions. Ignore it.
     del part_table[3]
 
     return part_table
+
+
+def get_var_for_actual_part(var_name, part_name, default=None):
+    """
+    Get the value of a partition config variable for a partition.
+
+    Args:
+    * var_name (str): name of partition property to get.
+    * part_name (str): name of partition.
+
+    Returns (str): the contents of the config file for the given variable name
+    and partition, or empty string if the config file doesn't exist.
+    """
+    path = part_name / var_name
+    if not path.is_file():
+        return ""
+    return path.read_text()
+
 
 
 def test_part_table():

--- a/mbl-core/tests/partitions/test_partitions.py
+++ b/mbl-core/tests/partitions/test_partitions.py
@@ -135,12 +135,10 @@ def get_var_for_actual_part(sys_part_info_file):
     information.
 
     Returns (str): the contents of the config file for the given variable name
-    and partition, or a string containing "0" if the config file doesn't exist.
+    and partition, or an exception if the config file doesn't exist.
     """
-    try:
-        return sys_part_info_file.read_text()
-    except FileNotFoundError:
-        return "0"
+    return sys_part_info_file.read_text()
+
 
 
 def test_part_table():


### PR DESCRIPTION
sfdisk is no longer in the distro so this test was failing. 
Changed to extract the data from /sys/block files instead. 