### PR TITLE
Added sleep for wifi to startup

### DIFF
--- a/ci/lava/tests/test-config-across-reboot.py
+++ b/ci/lava/tests/test-config-across-reboot.py
@@ -117,9 +117,10 @@ class TestConfigAcrossReboot:
 
     def test_get_wlan_ip_after_reboot(self, execute_helper):
         """Check the WLAN IP still exists after reboot."""
-        # Display the ifconfig of the DUT for debug of test failures.
-        self._ifconfig(execute_helper)
+        # Wait for the wlan to become available.
         time.sleep(60)
+
+        # Display the ifconfig of the DUT for debug of test failures.
         self._ifconfig(execute_helper)
 
         err, wlan_ip_address = self._get_wlan_ip(execute_helper)

--- a/ci/lava/tests/test-config-across-reboot.py
+++ b/ci/lava/tests/test-config-across-reboot.py
@@ -119,7 +119,7 @@ class TestConfigAcrossReboot:
         """Check the WLAN IP still exists after reboot."""
         # Display the ifconfig of the DUT for debug of test failures.
         self._ifconfig(execute_helper)
-        time.sleep(120)
+        time.sleep(60)
         self._ifconfig(execute_helper)
 
         err, wlan_ip_address = self._get_wlan_ip(execute_helper)
@@ -185,7 +185,7 @@ class TestConfigAcrossReboot:
 
         # Wait for the interface to be removed and the routing tables
         # etc to be updated
-        time.sleep(30)
+        time.sleep(60)
 
         # Display the ifconfig of the DUT for debug of test failures.
         self._ifconfig(execute_helper)

--- a/ci/lava/tests/test-config-across-reboot.py
+++ b/ci/lava/tests/test-config-across-reboot.py
@@ -119,6 +119,8 @@ class TestConfigAcrossReboot:
         """Check the WLAN IP still exists after reboot."""
         # Display the ifconfig of the DUT for debug of test failures.
         self._ifconfig(execute_helper)
+        time.sleep(120)
+        self._ifconfig(execute_helper)
 
         err, wlan_ip_address = self._get_wlan_ip(execute_helper)
         assert err == 0


### PR DESCRIPTION
Added a sleep after the reboot to allow for WiFi to startup. 
The startup takes up to 60 seconds on some platforms.

Also changed the sleep after the ethernet is disabled to 60 seconds.