### PR TITLE
update scripts: don't restart client halfway through update

### DIFF
--- a/cloud-services/mbl-cloud-client/scripts/apps_installer.sh
+++ b/cloud-services/mbl-cloud-client/scripts/apps_installer.sh
@@ -43,21 +43,6 @@ uaod_apps_file="$1"
     if [ "$app_update_rc" -ne 0 ]; then
         exit 47
     fi
-
-    # mbed-cloud-client does not currently support component update; it
-    # therefore expects the system receiving the update to be rebooted as
-    # a whole image is expected to have been updated.
-    # The registration process that kicks in at boot up notifies Pelion Device
-    # Management that the update was successfully applied.
-    #
-    # Until component updates is implemented, it is required to restart the
-    # instance of the client running as service in order to simulate the
-    # expected system reboot.
-    #
-    # It was deemed safe to reboot at this stage as no other step is expected
-    # at this point other than rebooting.
-    systemctl restart mbl-cloud-client
-    exit_on_error "$?"
 }
 
 update_apps_or_die "$1"

--- a/cloud-services/mbl-cloud-client/scripts/arm_update_activate.sh
+++ b/cloud-services/mbl-cloud-client/scripts/arm_update_activate.sh
@@ -102,4 +102,22 @@ if ! swupdate -i "$FIRMWARE_PATH"; then
 fi
 
 save_header_or_die "$HEADER"
+
+if [ -e "${TMP_DIR}/do_not_reboot" ]; then
+    # None of the component installers want a full reboot, but:
+    # mbed-cloud-client does not currently support component update; it
+    # therefore expects the system receiving the update to be rebooted as
+    # a whole image is expected to have been updated.
+    # The registration process that kicks in at boot up notifies Pelion Device
+    # Management that the update was successfully applied.
+    #
+    # Until component updates is implemented, it is required to restart the
+    # instance of the client running as service in order to simulate the
+    # expected system reboot.
+    #
+    # It was deemed safe to reboot at this stage as no other step is expected
+    # at this point other than rebooting.
+    systemctl restart mbl-cloud-client
+    exit_on_error "$?"
+fi
 exit 0


### PR DESCRIPTION
If we're doing a multi-component update that includes both an app update
and an update of a component that requires a reboot to take effect,
don't let the app install script restart the cloud client part way
through the update.

We only actually need to restart the cloud client if we aren't going to
do a full reboot anyway, and if we restart the client part way through a
multi-component update (before the HEADER file has been moved) then the
cloud client will get confused.

For IOTMBL-2661: Multi-component update with app via pelion broken