### PR TITLE
mbl-os-0.10 -> warrior-dev backport

### DIFF
--- a/ci/lava/dependencies/test-enable-wifi.py
+++ b/ci/lava/dependencies/test-enable-wifi.py
@@ -19,6 +19,8 @@ import pytest
 import re
 import time
 
+from helpers import download_from_url
+
 QCADriverUrl = (
     "https://www.nxp.com/lgfiles/NMG/MAD/YOCTO/firmware-qca-2.0.3.bin"
 )
@@ -27,9 +29,7 @@ QCADriverUrl = (
 class TestEnableWiFi:
     """Create python test environment on a device under test."""
 
-    def test_enable_wifi(
-        self, execute_helper, dut_addr, device, local_conf_file
-    ):
+    def test_enable_wifi(self, execute_helper, dut_addr, device):
         """Enable the Wifi on the device."""
         if (
             device == "imx7s-warp-mbl"
@@ -102,18 +102,19 @@ class TestEnableWiFi:
             if "qca9377" not in output:
                 # Not loaded so fetch the firmware and install it.
 
-                if os.path.exists(local_conf_file):
-                    os.chmod(local_conf_file, 0o777)
+                driver_file = download_from_url(QCADriverUrl)
+                if os.path.exists(driver_file):
+                    os.chmod(driver_file, 0o777)
 
                     ret, output, error = execute_helper.send_mbl_cli_command(
-                        ["put", local_conf_file, "/tmp"], dut_addr
+                        ["put", driver_file, "/tmp"], dut_addr
                     )
 
                     ret, output, error = execute_helper.send_mbl_cli_command(
                         [
                             "shell",
                             "/tmp/{} --auto-accept".format(
-                                os.path.basename(local_conf_file)
+                                os.path.basename(driver_file)
                             ),
                         ],
                         dut_addr,

--- a/ci/lava/helpers.py
+++ b/ci/lava/helpers.py
@@ -275,17 +275,6 @@ def get_app_info(app_name, dut_addr, execute_helper, app_output):
     return output
 
 
-def strings_grep(dut_addr, execute_helper, file_path, pattern):
-    """Run strings command on a file and grep for a pattern using mbl-cli."""
-    command = "strings {} | grep {}".format(file_path, pattern)
-    exit_code, output, error = execute_helper.send_mbl_cli_command(
-        ["shell", 'sh -l -c "{}"'.format(command)],
-        dut_addr,
-        raise_on_error=True,
-    )
-    return output.splitlines()[1]
-
-
 class ExecuteHelper:
     """Class to provide a wrapper for executing commands as a subprocess."""
 

--- a/ci/lava/tests/test-component-update.py
+++ b/ci/lava/tests/test-component-update.py
@@ -122,7 +122,7 @@ class TestComponentUpdate:
                         item["args"]["size_B"],
                     )
                     part_sha_256_test_info.append(
-                        (image_data["image_name"], item["args"], pre_timestamp)
+                        (image_data["image_name"], item["args"])
                     )
                 elif item["test_type"] == "file_sha256":
                     file_sha256_test_info.append(
@@ -257,7 +257,7 @@ class TestComponentUpdate:
 
     def _compare_partition_sha256(self, execute_helper):
         for item in part_sha_256_test_info:
-            img_name, data, before_result = item
+            img_name, data = item
             print("Testing partition sha256 for image {}".format(img_name))
             post_extracted_img = read_partition_to_file(
                 TestComponentUpdate.dut_address,

--- a/ci/lava/tests/test-component-update.py
+++ b/ci/lava/tests/test-component-update.py
@@ -36,7 +36,6 @@ from helpers import (
     get_app_info,
     get_mounted_bank_label,
     get_file_mtime,
-    strings_grep,
     get_pelion_device_id,
 )
 
@@ -121,12 +120,6 @@ class TestComponentUpdate:
                         item["args"]["part_name"],
                         "pre",
                         item["args"]["size_B"],
-                    )
-                    pre_timestamp = strings_grep(
-                        TestComponentUpdate.dut_address,
-                        execute_helper,
-                        pre_update_img,
-                        "Built",
                     )
                     part_sha_256_test_info.append(
                         (image_data["image_name"], item["args"], pre_timestamp)
@@ -277,15 +270,6 @@ class TestComponentUpdate:
                 post_extracted_img,
                 TestComponentUpdate.dut_address,
                 execute_helper,
-            )
-            assert (
-                strings_grep(
-                    TestComponentUpdate.dut_address,
-                    execute_helper,
-                    post_extracted_img,
-                    "Built",
-                )
-                != before_result
             )
 
     def _compare_file_sha256(self, execute_helper):

--- a/ci/lava/tests/test-component-update.py
+++ b/ci/lava/tests/test-component-update.py
@@ -323,22 +323,8 @@ class TestComponentUpdate:
             )
 
     def _compare_app_info(self, execute_helper):
-        for item in app_bank_test_info:
-            img_name, data = item
-            app_name = data["app_name"]
-            app_info = get_app_info(
-                app_name,
-                TestComponentUpdate.dut_address,
-                execute_helper,
-                app_output=False,
-            )
-            print(
-                "Checking the app {} is running and installed".format(app_name)
-            )
-            assert '"status": "running"' in app_info
-            assert '"bundle": "/home/app/{}/0'.format(app_name) in app_info
-        # Wait 30 seconds for the app to stop.
-        time.sleep(30)
+        # Wait few seconds for the app to start running
+        time.sleep(5)
         for item in app_bank_test_info:
             img_name, data = item
             app_name = data["app_name"]
@@ -349,9 +335,11 @@ class TestComponentUpdate:
                 app_output=True,
             )
             print(
-                "Checking the app {} is stopped and its output".format(
+                "Checking the app {} is installed and its output".format(
                     app_name
                 )
             )
-            assert '"status": "stopped"' in app_info
-            assert app_info.count("Hello, world") == 10
+            assert '"bundle": "/home/app/{}/0'.format(app_name) in app_info
+            # The app might still be running running, so just checking there is
+            # some output in the log.
+            assert app_info.count("Hello, world") > 0

--- a/ci/lava/tests/test-config-across-reboot.py
+++ b/ci/lava/tests/test-config-across-reboot.py
@@ -117,6 +117,9 @@ class TestConfigAcrossReboot:
 
     def test_get_wlan_ip_after_reboot(self, execute_helper):
         """Check the WLAN IP still exists after reboot."""
+        # Wait for the wlan to become available.
+        time.sleep(60)
+
         # Display the ifconfig of the DUT for debug of test failures.
         self._ifconfig(execute_helper)
 
@@ -183,7 +186,7 @@ class TestConfigAcrossReboot:
 
         # Wait for the interface to be removed and the routing tables
         # etc to be updated
-        time.sleep(30)
+        time.sleep(60)
 
         # Display the ifconfig of the DUT for debug of test failures.
         self._ifconfig(execute_helper)

--- a/cloud-services/mbl-cloud-client/scripts/apps_installer.sh
+++ b/cloud-services/mbl-cloud-client/scripts/apps_installer.sh
@@ -43,21 +43,6 @@ uaod_apps_file="$1"
     if [ "$app_update_rc" -ne 0 ]; then
         exit 47
     fi
-
-    # mbed-cloud-client does not currently support component update; it
-    # therefore expects the system receiving the update to be rebooted as
-    # a whole image is expected to have been updated.
-    # The registration process that kicks in at boot up notifies Pelion Device
-    # Management that the update was successfully applied.
-    #
-    # Until component updates is implemented, it is required to restart the
-    # instance of the client running as service in order to simulate the
-    # expected system reboot.
-    #
-    # It was deemed safe to reboot at this stage as no other step is expected
-    # at this point other than rebooting.
-    systemctl restart mbl-cloud-client
-    exit_on_error "$?"
 }
 
 update_apps_or_die "$1"

--- a/cloud-services/mbl-cloud-client/scripts/arm_update_activate.sh
+++ b/cloud-services/mbl-cloud-client/scripts/arm_update_activate.sh
@@ -102,4 +102,22 @@ if ! swupdate -i "$FIRMWARE_PATH"; then
 fi
 
 save_header_or_die "$HEADER"
+
+if [ -e "${TMP_DIR}/do_not_reboot" ]; then
+    # None of the component installers want a full reboot, but:
+    # mbed-cloud-client does not currently support component update; it
+    # therefore expects the system receiving the update to be rebooted as
+    # a whole image is expected to have been updated.
+    # The registration process that kicks in at boot up notifies Pelion Device
+    # Management that the update was successfully applied.
+    #
+    # Until component updates is implemented, it is required to restart the
+    # instance of the client running as service in order to simulate the
+    # expected system reboot.
+    #
+    # It was deemed safe to reboot at this stage as no other step is expected
+    # at this point other than rebooting.
+    systemctl restart mbl-cloud-client
+    exit_on_error "$?"
+fi
 exit 0


### PR DESCRIPTION
* 62668ad - Fix WiFi enable on imx devices. (#260)
* e131f1c - update scripts: don't restart client halfway through update (#258)
* 838c065 - Added sleep for allow wifi to startup (#257)
* ab2485f - Fix component update test
* 706ba97 - Drop strings checks
* bca7b72 - Fix app test verification 