### PR TITLE
Check return code from pytest on DUT

### DIFF
--- a/ci/lava/tests/test-cellular-and-wifi-host.py
+++ b/ci/lava/tests/test-cellular-and-wifi-host.py
@@ -56,7 +56,7 @@ class TestCellularAndWifiHost:
             # processed by LAVA.
             print(output)
 
-            assert True
+            assert return_code == 0
         else:
             print(
                 "Device {} does not support cellular modules.".format(device)

--- a/ci/lava/tests/test-core-component.py
+++ b/ci/lava/tests/test-core-component.py
@@ -126,7 +126,7 @@ class TestCoreComponentDUT:
         # processed by LAVA.
         print(output)
 
-        assert True
+        assert return_code == 0
 
     def _download_and_copy_app_payloads(
         self, payloads_url, execute_helper, dut_artifacts_dir, dut_addr


### PR DESCRIPTION
If the pytest running on the DUT fails the overall test does not register this as a failure. 
The return_code are checked against 0 to ensure something in the test execution fails.