### PR TITLE
Don't rely on rootfs labels in badblocks test

### DIFF
--- a/ci/lava/tests/test-bsp.py
+++ b/ci/lava/tests/test-bsp.py
@@ -27,7 +27,8 @@ class TestBSP:
             [
                 "shell",
                 'sh -l -c "badblocks -v '
-                "/dev/$(cat /config/factory/part-info/MBL_ROOT_DEVICE_NAME_BANK1)"
+                "/dev/"
+                "$(cat /config/factory/part-info/MBL_ROOT_DEVICE_NAME_BANK1)"
                 '"',
             ],
             TestBSP.dut_address,

--- a/ci/lava/tests/test-bsp.py
+++ b/ci/lava/tests/test-bsp.py
@@ -27,7 +27,7 @@ class TestBSP:
             [
                 "shell",
                 'sh -l -c "badblocks -v '
-                "$(/sbin/blkid -L rootfs1 | sed 's/p[0-9]+$//')"
+                "/dev/$(cat /config/factory/part-info/MBL_ROOT_DEVICE_NAME_BANK1)"
                 '"',
             ],
             TestBSP.dut_address,


### PR DESCRIPTION
We shouldn't rely on the two banks of the rootfs partition having the
labels "rootfs1" and "rootfs2" because once we start using ext4 images
as our rootfs update payloads the labels of the file systems will be set
before we know which banks they end up in.

Find the name of the device that holds the rootfs by looking in our info
files in /config/factory/part-info instead.

For IOTMBL-2656: Robust update: don't rely on root filesystem labels