### PR TITLE
swupdate-handlers: Use a compile time constant when declaring an array.

### DIFF
--- a/firmware-management/swupdate-handlers/arm-handler-common.c
+++ b/firmware-management/swupdate-handlers/arm-handler-common.c
@@ -116,7 +116,7 @@ int get_mounted_device(char *const dst, const char *const mount_point, const siz
         {
             strncpy(dst, mntent_desc->mnt_fsname, dst_size);
 
-            if (dst[dst_size] != '\0')
+            if (dst[dst_size-1] != '\0')
             {
                 ERROR("%s %s", mntent_desc->mnt_fsname, "could not fit into destination buffer and was truncated");
                 return_val = -1;

--- a/firmware-management/swupdate-handlers/arm-handler-common.h.in
+++ b/firmware-management/swupdate-handlers/arm-handler-common.h.in
@@ -10,6 +10,8 @@
 #include "swupdate/swupdate.h"
 #include <stddef.h>
 
+#define MAX_DEVICE_FILE_PATH 512
+
 static const char *const BOOTFLAGS_DIR = "@BOOTFLAGS_DIR@";
 static const char *const UPDATE_PAYLOAD_DIR = "@UPDATE_PAYLOAD_DIR@";
 static const char *const LOG_DIR = "@LOG_DIR@";

--- a/firmware-management/swupdate-handlers/rootfs-handler.c
+++ b/firmware-management/swupdate-handlers/rootfs-handler.c
@@ -19,7 +19,6 @@
 
 int rootfsv4_handler(struct img_type *img, void __attribute__ ((__unused__)) *data)
 {
-    static const size_t MAX_DEVICE_FILE_PATH = 512;
     static const char *const root_mnt_point = "/";
 
     char mounted_device_filepath[MAX_DEVICE_FILE_PATH];


### PR DESCRIPTION
This patch also fixes an incorrect null terminator check in
get_mounted_device.