### PR TITLE
firmware-management:updated: Add logging mechanism

### DIFF
--- a/firmware-management/updated/updated/CMakeLists.txt
+++ b/firmware-management/updated/updated/CMakeLists.txt
@@ -13,6 +13,8 @@ set(UPDATED_SRC
 
     source/rpc/Server.cpp
     source/rpc/ServiceImpl.cpp
+
+    source/logging/logger.cpp
 )
 
 add_executable(updated ${UPDATED_SRC})

--- a/firmware-management/updated/updated/CMakeLists.txt
+++ b/firmware-management/updated/updated/CMakeLists.txt
@@ -6,10 +6,6 @@ cmake_minimum_required(VERSION 3.5)
 
 include(GNUInstallDirs)
 
-if(${RUN_CODE_CHECKS})
-    find_package(spdlog REQUIRED)
-endif()
-
 set(UPDATED_SRC
     source/init.cpp
     source/updated.cpp
@@ -26,9 +22,5 @@ target_link_libraries(updated common_compile_options)
 target_link_libraries(updated common_compile_warnings)
 target_link_libraries(updated updated-rpc)
 target_link_libraries(updated systemd)
-
-if(${RUN_CODE_CHECKS})
-    target_link_libraries(updated spdlog::spdog)
-endif()
 
 install(TARGETS updated DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/firmware-management/updated/updated/CMakeLists.txt
+++ b/firmware-management/updated/updated/CMakeLists.txt
@@ -6,6 +6,10 @@ cmake_minimum_required(VERSION 3.5)
 
 include(GNUInstallDirs)
 
+if(${RUN_CODE_CHECKS})
+    find_package(spdlog REQUIRED)
+endif()
+
 set(UPDATED_SRC
     source/init.cpp
     source/updated.cpp
@@ -22,4 +26,9 @@ target_link_libraries(updated common_compile_options)
 target_link_libraries(updated common_compile_warnings)
 target_link_libraries(updated updated-rpc)
 target_link_libraries(updated systemd)
+
+if(${RUN_CODE_CHECKS})
+    target_link_libraries(updated spdlog::spdog)
+endif()
+
 install(TARGETS updated DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/firmware-management/updated/updated/source/Manifest.h
+++ b/firmware-management/updated/updated/source/Manifest.h
@@ -11,8 +11,10 @@
 
 namespace updated {
 
-/** Manifest contains information about an update bundle.
- *  Currently this object just contains the data from the update HEADER file.
+/**
+ * Manifest contains information about an update bundle.
+ *
+ * Currently this object just contains the data from the update HEADER file.
  */
 struct Manifest final
 {

--- a/firmware-management/updated/updated/source/UpdateCoordinator.h
+++ b/firmware-management/updated/updated/source/UpdateCoordinator.h
@@ -18,29 +18,32 @@
 
 namespace updated {
 
-/** Coordinate asynchronous updates.
+/**
+ * Coordinate asynchronous updates.
  *
- *  UpdateCoordinator is the core object responsible for updates.
- *  After instantiating the UpdateCoordinator you must call the run method,
- *  which will block the current thread until the start method is called.
- *  This design was chosen to allow UpdateD's RPC server to trigger an update
- *  asynchronously.
+ * UpdateCoordinator is the core object responsible for updates.
+ * After instantiating the UpdateCoordinator you must call the run method,
+ * which will block the current thread until the start method is called.
+ * This design was chosen to allow UpdateD's RPC server to trigger an update
+ * asynchronously.
  */
 class UpdateCoordinator final
 {
 public:
     UpdateCoordinator() = default;
 
-    /** Start an update.
+    /**
+     * Start an update.
      *
-     *  This method is ALWAYS called on a different thread to UpdateCoordinator::run
+     * This method is ALWAYS called on a different thread to UpdateCoordinator::run
      */
     void start(const std::filesystem::path &payload_path, std::string header_data) noexcept;
 
-    /** Run an update transaction.
+    /**
+     * Run an update transaction.
      *
-     *  Block the main thread and wait until an update request arrives.
-     *  When the request arrives delegate the update to a component installer.
+     * Block the main thread and wait until an update request arrives.
+     * When the request arrives delegate the update to a component installer.
      */
     void run();
 

--- a/firmware-management/updated/updated/source/cli.h
+++ b/firmware-management/updated/updated/source/cli.h
@@ -39,6 +39,7 @@ std::string parse_args(const int argc, char **argv)
 {
     if (argc < 2)
     {
+        // No arguments given, we return the default log_level.
         return "INFO";
     }
 

--- a/firmware-management/updated/updated/source/cli.h
+++ b/firmware-management/updated/updated/source/cli.h
@@ -28,7 +28,7 @@ UpdateD, a system daemon that coordinates firmware updates.
 Example: updated -l CRITICAL
 
 Options:
-    -l          Set the logging level. Possible values: CRITICAL|ERROR|WARNING|INFO|DEBUG|TRACE
+    -l          Set the logging level (default INFO). Possible values: CRITICAL|ERROR|WARNING|INFO|DEBUG|TRACE
 )";
 }
 
@@ -39,14 +39,14 @@ std::string parse_args(const int argc, char **argv)
 {
     if (argc < 2)
     {
-        throw std::invalid_argument("No arguments given!");
+        return "INFO";
     }
 
     int current_opt;
     int optindex;
 
     static const std::vector<option> long_opts {
-        {"log-level", required_argument, nullptr, 'l'},
+        {"log-level", optional_argument, nullptr, 'l'},
         {"help", no_argument, nullptr, 'h'}
     };
 

--- a/firmware-management/updated/updated/source/cli.h
+++ b/firmware-management/updated/updated/source/cli.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2020 Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef UPDATED_CLI_H
+#define UPDATED_CLI_H
+
+#include <cstring>
+#include <iostream>
+#include <string>
+#include <stdexcept>
+#include <vector>
+
+#include <getopt.h>
+
+namespace updated {
+namespace cli {
+
+/**
+ * Return help text.
+ */
+const char* usage()
+{
+    return R"(Usage: updated [-l] CRITICAL|ERROR|WARNING|INFO|DEBUG|TRACE
+UpdateD, a system daemon that coordinates firmware updates.
+Example: updated -l CRITICAL
+
+Options:
+    -l          Set the logging level. Possible values: CRITICAL|ERROR|WARNING|INFO|DEBUG|TRACE
+)";
+}
+
+/**
+ * Parse command line arguments.
+ */
+std::string parse_args(const int argc, char **argv)
+{
+    if (argc < 2)
+    {
+        throw std::invalid_argument("No arguments given!");
+    }
+
+    int current_opt;
+    int optindex;
+
+    static const std::vector<option> long_opts {
+        {"log-level", required_argument, nullptr, 'l'},
+        {"help", no_argument, nullptr, 'h'}
+    };
+
+    while ((current_opt = getopt_long(argc, argv, "l:h", long_opts.data(), &optindex)) != -1)
+    {
+        switch (current_opt)
+        {
+            case 'l':
+                if (!std::strcmp(optarg, "CRITICAL") || !std::strcmp(optarg, "ERROR")
+                        || !std::strcmp(optarg, "WARNING") || !std::strcmp(optarg, "INFO")
+                        || !std::strcmp(optarg, "DEBUG") || !std::strcmp(optarg, "TRACE"))
+                {
+                    return optarg;
+                }
+                else
+                {
+                    std::cout << usage() << '\n';
+                    throw std::invalid_argument("Invalid log level given!");
+                }
+            case 'h':
+                std::cout << usage() << '\n';
+                std::exit(0);
+            case '?':
+                std::cout << usage() << '\n';
+                throw std::invalid_argument("Unrecognized argument!");
+            default:
+                break;
+        }
+    }
+
+    std::cout << usage() << '\n';
+    throw std::invalid_argument("Unrecognized arguments!");
+}
+
+} // namespace cli
+} // namespace updated
+
+#endif // UPDATED_CLI_H

--- a/firmware-management/updated/updated/source/fileutils/payload.h
+++ b/firmware-management/updated/updated/source/fileutils/payload.h
@@ -13,12 +13,13 @@
 namespace updated {
 namespace fileutils {
 
-/** Manage a hard link to an update payload
+/**
+ * Manage a hard link to an update payload
  *
- *  This object will create the hard link in a temporary directory, and ensure
- *  it is cleaned up in an exception safe way.
- *  If the temporary directory already exists, it and its contents are removed
- *  before creating the hard link.
+ * This object will create the hard link in a temporary directory, and ensure
+ * it is cleaned up in an exception safe way.
+ * If the temporary directory already exists, it and its contents are removed
+ * before creating the hard link.
  */
 class PayloadHardLink final
 {

--- a/firmware-management/updated/updated/source/init.cpp
+++ b/firmware-management/updated/updated/source/init.cpp
@@ -16,7 +16,7 @@
 namespace updated {
 namespace init {
 
-Status initialise(const InitData init_data)
+Status initialise(const InitData &init_data)
 {
     logging::create_systemd_logger(
         logging::level_from_string(init_data.log_level)

--- a/firmware-management/updated/updated/source/init.cpp
+++ b/firmware-management/updated/updated/source/init.cpp
@@ -9,15 +9,18 @@
  */
 
 #include "init.h"
+#include "logging/logger.h"
 
 #include <systemd/sd-daemon.h>
-
 
 namespace updated {
 namespace init {
 
-Status initialise()
+Status initialise(const InitData init_data)
 {
+    logging::create_systemd_logger(
+        logging::level_from_string(init_data.log_level)
+    );
     return Status::Started;
 }
 

--- a/firmware-management/updated/updated/source/init.h
+++ b/firmware-management/updated/updated/source/init.h
@@ -42,7 +42,7 @@ struct InitData
  *
  * Returns init::Status, which is used to notify the init system.
  */
-Status initialise(InitData init_data);
+Status initialise(const InitData &init_data);
 
 /**
  * Notify systemd that UpdateD started.

--- a/firmware-management/updated/updated/source/init.h
+++ b/firmware-management/updated/updated/source/init.h
@@ -7,8 +7,11 @@
 /**
  * This module contains initialisation functions and state
  */
+
 #ifndef UPDATED_INIT_H
 #define UPDATED_INIT_H
+
+#include <string>
 
 namespace updated {
 namespace init {
@@ -19,18 +22,32 @@ enum class Status
     FailedToStart,
 };
 
-/** Initialise UpdateD.
- *
- *  This is where we add our signal handlers, initialise our logging
- *  mechanism and perform any other startup housekeeping.
- *
- *  Returns init::Status, which is used to notify the init system.
+/**
+ * InitData contains initialisation state for UpdateD
  */
-Status initialise();
+struct InitData
+{
+    std::string log_level;
 
-/** Notify systemd that UpdateD started.
+    InitData(std::string log_lvl)
+        : log_level{log_lvl}
+    {}
+};
+
+/**
+ * Initialise UpdateD.
  *
- *  Take an init::Status and use it to notify systemd of the startup status.
+ * This is where we add our signal handlers, initialise our logging
+ * mechanism and perform any other startup housekeeping.
+ *
+ * Returns init::Status, which is used to notify the init system.
+ */
+Status initialise(InitData init_data);
+
+/**
+ * Notify systemd that UpdateD started.
+ *
+ * Take an init::Status and use it to notify systemd of the startup status.
  */
 void notify_start(Status startup_status);
 

--- a/firmware-management/updated/updated/source/logging/logger.cpp
+++ b/firmware-management/updated/updated/source/logging/logger.cpp
@@ -6,12 +6,14 @@
 
 #include "logger.h"
 
+#include <string_view>
+
 namespace updated {
 namespace logging {
 
 namespace {
 
-static constexpr char LOGGER_NAME[] = "systemd";
+constexpr auto LOGGER_NAME = "systemd";
 
 void set_global_level(Level level)
 {

--- a/firmware-management/updated/updated/source/logging/logger.cpp
+++ b/firmware-management/updated/updated/source/logging/logger.cpp
@@ -13,6 +13,8 @@ namespace logging {
 
 namespace {
 
+constexpr auto LOGGER_NAME = "systemd";
+
 void set_global_level(Level level)
 {
     switch (level)
@@ -54,7 +56,7 @@ Level level_from_string(const std::string_view str)
 
 std::shared_ptr<spdlog::logger> create_systemd_logger(Level level)
 {
-    auto logger = spdlog::systemd_logger_mt("systemd"); // NOLINT: spdlog misuses std::move, disable checking here
+    auto logger = spdlog::systemd_logger_mt(LOGGER_NAME); // NOLINT: spdlog misuses std::move, disable checking here
     set_global_level(level);
     return logger;
 }

--- a/firmware-management/updated/updated/source/logging/logger.cpp
+++ b/firmware-management/updated/updated/source/logging/logger.cpp
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2020 Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "logger.h"
+
+namespace updated {
+namespace logging {
+
+namespace {
+
+static constexpr char LOGGER_NAME[] = "systemd";
+
+void set_global_level(Level level)
+{
+    switch (level)
+    {
+    case Level::CRITICAL:
+        spdlog::set_level(spdlog::level::critical);
+        break;
+    case Level::ERROR:
+        spdlog::set_level(spdlog::level::err);
+        break;
+    case Level::WARN:
+        spdlog::set_level(spdlog::level::warn);
+        break;
+    case Level::INFO:
+        spdlog::set_level(spdlog::level::info);
+        break;
+    case Level::DEBUG:
+        spdlog::set_level(spdlog::level::debug);
+        break;
+    case Level::TRACE:
+        spdlog::set_level(spdlog::level::trace);
+        break;
+    }
+}
+
+} // anonymous namespace
+
+Level level_from_string(const std::string_view str)
+{
+    if (str == "CRITICAL") return Level::CRITICAL;
+    if (str == "ERROR") return Level::ERROR;
+    if (str == "WARNING") return Level::WARN;
+    if (str == "INFO") return Level::INFO;
+    if (str == "DEBUG") return Level::DEBUG;
+    if (str == "TRACE") return Level::TRACE;
+
+    throw std::invalid_argument("Unrecognized string level.");
+}
+
+std::shared_ptr<spdlog::logger> create_systemd_logger(Level level)
+{
+    auto logger = spdlog::systemd_logger_mt(LOGGER_NAME);
+    set_global_level(level);
+    return logger;
+}
+
+std::shared_ptr<spdlog::logger> get_logger()
+{
+    return spdlog::get(LOGGER_NAME);
+}
+
+} // namespace logging
+} // namespace updated
+
+

--- a/firmware-management/updated/updated/source/logging/logger.cpp
+++ b/firmware-management/updated/updated/source/logging/logger.cpp
@@ -44,19 +44,19 @@ void set_global_level(Level level)
 
 Level level_from_string(const std::string_view str)
 {
-    if (str == "CRITICAL") return Level::CRITICAL;
-    if (str == "ERROR") return Level::ERROR;
-    if (str == "WARNING") return Level::WARN;
-    if (str == "INFO") return Level::INFO;
-    if (str == "DEBUG") return Level::DEBUG;
-    if (str == "TRACE") return Level::TRACE;
+    if (str == "CRITICAL") { return Level::CRITICAL; }
+    if (str == "ERROR") { return Level::ERROR; }
+    if (str == "WARNING") { return Level::WARN; }
+    if (str == "INFO") { return Level::INFO; }
+    if (str == "DEBUG") { return Level::DEBUG; }
+    if (str == "TRACE") { return Level::TRACE; }
 
     throw std::invalid_argument("Unrecognized string level.");
 }
 
 std::shared_ptr<spdlog::logger> create_systemd_logger(Level level)
 {
-    auto logger = spdlog::systemd_logger_mt(LOGGER_NAME);
+    auto logger = spdlog::systemd_logger_mt("systemd"); // NOLINT: spdlog misuses std::move, disable checking here
     set_global_level(level);
     return logger;
 }

--- a/firmware-management/updated/updated/source/logging/logger.cpp
+++ b/firmware-management/updated/updated/source/logging/logger.cpp
@@ -13,8 +13,6 @@ namespace logging {
 
 namespace {
 
-constexpr auto LOGGER_NAME = "systemd";
-
 void set_global_level(Level level)
 {
     switch (level)

--- a/firmware-management/updated/updated/source/logging/logger.h
+++ b/firmware-management/updated/updated/source/logging/logger.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2020 Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef UPDATED_LOGGING_H
+#define UPDATED_LOGGING_H
+
+#include "spdlog/spdlog.h"
+#include "spdlog/sinks/systemd_sink.h"
+
+#include <memory>
+#include <string_view>
+
+namespace updated {
+namespace logging {
+
+/* Create aliases for spdlog levels in our namespace */
+using spdlog::trace;
+using spdlog::info;
+using spdlog::debug;
+using spdlog::error;
+using spdlog::critical;
+using spdlog::warn;
+
+enum class Level
+{
+    CRITICAL,
+    ERROR,
+    WARN,
+    INFO,
+    DEBUG,
+    TRACE
+};
+
+/**
+ * Takes a string log level and returns a logging::Level.
+ *
+ * Valid levels are: CRITICAL, ERROR, WARNING, INFO, DEBUG or TRACE
+ */
+Level level_from_string(const std::string_view str);
+
+/**
+ * Creates a global logger with a systemd log sink.
+ */
+std::shared_ptr<spdlog::logger> create_systemd_logger(Level level);
+
+/**
+ * Get a shared_ptr to the global logger.
+ */
+std::shared_ptr<spdlog::logger> get_logger();
+
+} // namespace logging
+} // namespace updated
+
+
+#endif // UPDATED_LOGGING_H

--- a/firmware-management/updated/updated/source/rpc/ServiceImpl.cpp
+++ b/firmware-management/updated/updated/source/rpc/ServiceImpl.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "ServiceImpl.h"
+#include "../logging/logger.h"
 
 #include <exception>
 
@@ -34,7 +35,7 @@ grpc::Status ServiceImpl::StartUpdate(
     }
     catch(std::exception &e)
     {
-        std::cerr << e.what() << '\n';
+        logging::error(e.what());
         response->set_value(ErrorCodeMessage::UNKNOWN_ERROR);
         return grpc::Status::CANCELLED;
     }

--- a/firmware-management/updated/updated/source/updated.cpp
+++ b/firmware-management/updated/updated/source/updated.cpp
@@ -4,27 +4,30 @@
  * SPDX-License-Identifier: BSD-3-Clause
  *
  * UpdateD (pronounced update-dee) is a system daemon that coordinates updates
- * to device firmware.  Updates will consist of bundles of one or more
- * firmware packages that should be applied as a set.  The delivery of updates
+ * to device firmware. Updates will consist of bundles of one or more
+ * firmware packages that should be applied as a set. The delivery of updates
  * to a device will be the responsibility of an external delivery mechanism.
  * UpdateD runs in the background on a device and listens for update requests.
  * When a request is received, UpdateD will hand off responsibility for applying
  * the update to swupdate.
  */
 
+#include "cli.h"
 #include "init.h"
+#include "UpdateCoordinator.h"
+#include "logging/logger.h"
 
 #include "rpc/Server.h"
 
-#include "UpdateCoordinator.h"
-
 #include <unistd.h>
 
-int main()
+int main(int argc, char** argv)
 {
+    const auto log_level = updated::cli::parse_args(argc, argv);
+
     updated::UpdateCoordinator update_coordinator;
     updated::rpc::Server rpc_server{update_coordinator};
-    const updated::init::Status init_status = updated::init::initialise();
+    const updated::init::Status init_status = updated::init::initialise({log_level});
     updated::init::notify_start(init_status);
 
     while(true)

--- a/firmware-management/updated/updated/source/updated.cpp
+++ b/firmware-management/updated/updated/source/updated.cpp
@@ -19,11 +19,24 @@
 
 #include "rpc/Server.h"
 
+#include <string>
+#include <stdexcept>
 #include <unistd.h>
 
 int main(int argc, char** argv)
 {
-    const auto log_level = updated::cli::parse_args(argc, argv);
+    std::string log_level;
+
+    try
+    {
+        log_level = updated::cli::parse_args(argc, argv);
+    }
+    catch (std::invalid_argument &e)
+    {
+        std::cerr << e.what() << '\n';
+        updated::init::notify_start(updated::init::Status::FailedToStart);
+        return 1;
+    }
 
     updated::UpdateCoordinator update_coordinator;
     updated::rpc::Server rpc_server{update_coordinator};


### PR DESCRIPTION
We use the spdlog library as our logging framework in UpdateD.

This commit adds:
* Wrapper code for the spdlog library.
* Command line argument to set the desired log level.